### PR TITLE
2313a

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -1651,7 +1651,7 @@ x61.menu.clock.1MHz_external.build.f_cpu=1000000L
 #########################
 
 # General
-x313.name=ATtiny2313/4313
+x313.name=ATtiny2313(A)/4313
 x313.upload.tool=avrdude
 x313.upload.speed={bootloader.baudrate}
 x313.bootloader.tool=avrdude
@@ -1691,6 +1691,11 @@ x313.menu.chip.4313.upload.maximum_data_size=256
 
 x313.menu.chip.2313=ATtiny2313
 x313.menu.chip.2313.build.mcu=attiny2313
+x313.menu.chip.2313.upload.maximum_size=2048
+x313.menu.chip.2313.upload.maximum_data_size=128
+
+x313.menu.chip.2313=ATtiny2313A
+x313.menu.chip.2313.build.mcu=attiny2313a
 x313.menu.chip.2313.upload.maximum_size=2048
 x313.menu.chip.2313.upload.maximum_data_size=128
 


### PR DESCRIPTION
Need to add 2313A since for debugging (and also some other small things), it is different from 2313. Most importantly, the OCD register is at a different address. And the A version has a few more and improved peripherals (see https://ww1.microchip.com/downloads/en/Appnotes/doc8261.pdf).