### PR TITLE
43U has 16 digital pins

### DIFF
--- a/avr/variants/tiny43/pins_arduino.h
+++ b/avr/variants/tiny43/pins_arduino.h
@@ -20,7 +20,7 @@
 #define ATTINY43 1
 #define __AVR_ATtiny43__
 
-#define NUM_DIGITAL_PINS  (12)
+#define NUM_DIGITAL_PINS  (16)
 #define NUM_ANALOG_INPUTS ( 4)
 
 /* Basic Pin Numbering - PIN_Pxn notation is always recommended


### PR DESCRIPTION
A typo in pin_arduino.h of the Tiny43U. No idea how long it has been there. I noticed when running the analog read tests on it.