### PR TITLE
Moretests

### DIFF
--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -14,23 +14,23 @@ The tests in this folder each check one particular basic functionality. They are
 
 
 
-| Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | *ATtiny828* | ATtiny43 | ATtiny26 |
-| ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | ----------- | -------- | -------- |
-| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🟢        |
-| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🔴        |
-| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🟢        |
-| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️           | 🟢        | 🟢        |
-| SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🔴        | 🔴        |
-| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | ⚪️           | ⚫️        | ⚫️        |
-| Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🔴        |
-| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🔴        | 🔴        |
-| Neopixel library/libraries                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🔴        |
-| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🔴        | 🔴        |
+| Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | ATtiny828 | ATtiny43 | ATtiny26 |
+| ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
+| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
+| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
+| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🟢        |
+| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | 🟡         | 🟢        | 🟢        |
+| SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🔴        | 🔴        |
+| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | 🔴         | ⚫️        | ⚫️        |
+| Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
+| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🔴        | 🔴        |
+| Neopixel library/libraries                  | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟡         | 🟢        | 🔴        |
+| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🔴        | 🔴        |
 
 🟢 = Works
 🔴 = Does not work
 🟡 = Partially works
-⚫️ = Not present
+⚫️ = Not present / Not implemented
 ⚪️ = Untested
 
 ATtiny26:
@@ -58,3 +58,10 @@ ATtiny43U:
 - Servo: Compiler message: Not supported
 - Wire slave: Does not start
 - SPI master: No transfer (in 1.5.2 core: compilation error)
+
+ATtiny828:
+
+- Neopixel does not work on: 6,7,8,9,11, ...? Does not work on 1.5.2 either on pin 11, even if I set Neopixel port to PORTB.
+- Wire Master & Salve use apparently my bitbang I2C lib SoftI2CMaster and fail with a compilation error
+- Reading analog values: Wildly wrong and huge differences. Even when measuring individually, the values are way off (with the 1.5.2 core, it is the same; maybe it is a problem with the sample?)
+- Does not work at all. Under the 1.5.2 core it works for pins 20-22 (but not for 16).

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -20,8 +20,8 @@ The tests in this folder each check one particular basic functionality. They are
 | `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
 | `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟡        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| SPI master                                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| SPI slave                                   | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| SPI master                                  | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| SPI slave                                   | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Wire slave                                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Neopixel library/libraries                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
@@ -40,3 +40,8 @@ ATtiny26:
 ATtinyX7:
 
 - Serial: TX works, RX does not
+
+ATtiny85:
+
+- SPI master does not work
+- SPI slave does not compile, because some SPI registers are missing. I guess, one needs a different script 

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -14,18 +14,18 @@ The tests in this folder each check one particular basic functionality. They are
 
 
 
-| Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | ATtiny828 | ATtiny43 | ATtiny26 |
-| ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
-| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
-| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | 🔴        |
-| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | ⚪️         | ⚫️        | ⚫️        |
-| Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | 🔴        |
-| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | 🔴        |
-| Neopixel library/libraries                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | ⚪️         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | *ATtiny828* | ATtiny43 | ATtiny26 |
+| ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | ----------- | -------- | -------- |
+| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🟢        |
+| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🔴        |
+| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🟢        |
+| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️           | 🟢        | 🟢        |
+| SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🔴        | 🔴        |
+| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | ⚪️           | ⚫️        | ⚫️        |
+| Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🔴        |
+| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🔴        | 🔴        |
+| Neopixel library/libraries                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🟢        | 🔴        |
+| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️           | 🔴        | 🔴        |
 
 🟢 = Works
 🔴 = Does not work
@@ -36,7 +36,8 @@ The tests in this folder each check one particular basic functionality. They are
 ATtiny26:
 
 - analogWrite: PWM does not work on either PWM pin (9 and 11)
-- Wire Master & Slave, SPI master: Not enough memory for test sketch
+- Wire Master & Slave, SPI master, Neopixel: Not enough memory for test sketch
+- Servo: Compilation error
 
 ATtiny85:
 
@@ -52,3 +53,8 @@ ATtiny861:
 
 - SPI master: Message is not received by slave 
 
+ATtiny43U:
+
+- Servo: Compiler message: Not supported
+- Wire slave: Does not start
+- SPI master: No transfer (in 1.5.2 core: compilation error)

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -17,7 +17,7 @@ The tests in this folder each check one particular basic functionality. They are
 | Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | ATtiny828 | ATtiny43 | ATtiny26 |
 | ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
 | `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🟢        |
-| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🔴        |
+| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
 | `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | 🟢         | 🟢        | 🟢        |
 | SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🔴        | 🔴        |

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -20,12 +20,12 @@ The tests in this folder each check one particular basic functionality. They are
 | `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
 | `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| SPI master                                  | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | ⚪️        | 🟢        | ⚫️          | ⚫️          | ⚪️         | ⚫️        | ⚫️        |
-| Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Neopixel library/libraries                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | 🔴        |
+| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | ⚪️         | ⚫️        | ⚫️        |
+| Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | 🔴        |
+| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | 🔴        |
+| Neopixel library/libraries                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | ⚪️         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 
 🟢 = Works
 🔴 = Does not work
@@ -36,12 +36,19 @@ The tests in this folder each check one particular basic functionality. They are
 ATtiny26:
 
 - analogWrite: PWM does not work on either PWM pin (9 and 11)
-
-ATtinyX7:
-
-- Serial: TX works, RX does not
+- Wire Master & Slave, SPI master: Not enough memory for test sketch
 
 ATtiny85:
 
 - SPI master does not work
-- SPI slave does not compile, because some SPI registers are missing. I guess, one needs a different script 
+
+ATtiny167:
+
+- TWI slave: Stops after a few interactions and is stuck in waiting for the serial output buffer to become empty (same behavior as in the 1.5.2 core)
+
+- SPI master: Stops in the middle of the test. Perhaps a similar problem as above.
+
+ATtiny861:
+
+- SPI master: Message is not received by slave 
+

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -19,12 +19,12 @@ The tests in this folder each check one particular basic functionality. They are
 | `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
 | `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🟢        |
-| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | 🟡         | 🟢        | 🟢        |
+| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | 🟢         | 🟢        | 🟢        |
 | SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🔴        | 🔴        |
 | SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | 🔴         | ⚫️        | ⚫️        |
 | Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
 | Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🔴        | 🔴        |
-| Neopixel library/libraries                  | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟡         | 🟢        | 🔴        |
+| Neopixel library/libraries                  | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🔴        |
 | Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🔴        | 🔴        |
 
 🟢 = Works
@@ -61,7 +61,7 @@ ATtiny43U:
 
 ATtiny828:
 
-- Neopixel does not work on: 6,7,8,9,11, ...? Does not work on 1.5.2 either on pin 11, even if I set Neopixel port to PORTB.
+- <s>Neopixel does not work on: 6,7,8,9,11, ...? Does not work on 1.5.2 either on pin 11, even if I set Neopixel port to PORTB</s>  *was the board hardware* 
 - Wire Master & Salve use apparently my bitbang I2C lib SoftI2CMaster and fail with a compilation error
-- Reading analog values: Wildly wrong and huge differences. Even when measuring individually, the values are way off (with the 1.5.2 core, it is the same; maybe it is a problem with the sample?)
-- Does not work at all. Under the 1.5.2 core it works for pins 20-22 (but not for 16).
+- <s>Reading analog values: Wildly wrong and huge differences. Even when measuring individually, the values are way off (with the 1.5.2 core, it is the same; maybe it is a problem with the sample?)  </s> *Was probably the board!*
+- analogWrite: Does not work at all. Under the 1.5.2 core it works for pins 20-22 (but not for 16). This still holds for the new hardware setup.

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -16,10 +16,10 @@ The tests in this folder each check one particular basic functionality. They are
 
 | Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | ATtiny828 | ATtiny43 | ATtiny26 |
 | ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
-| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
+| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
+| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
 | `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟡        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
+| `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | SPI master                                  | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | SPI slave                                   | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -18,14 +18,14 @@ The tests in this folder each check one particular basic functionality. They are
 | ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
 | `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
-| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟡        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
+| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟡        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | SPI master                                  | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | SPI slave                                   | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Neopixel library/libraries                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Neopixel library/libraries                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 
 🟢 = Works
 🔴 = Does not work

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -16,12 +16,12 @@ The tests in this folder each check one particular basic functionality. They are
 
 | Tests                                       | ATtinyX5 | ATtinyX4 | ATtinyX41 | ATtinyX61 | ATtinyX7 | ATtinyX8 | ATtinyX313 | ATtiny1634 | ATtiny828 | ATtiny43 | ATtiny26 |
 | ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
-| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
-| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
+| `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🟢        |
+| `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🔴        |
 | `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | 🟢         | 🟢        | 🟢        |
 | SPI master                                  | 🔴        | ⚪️        | ⚪️         | 🔴         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🔴        | 🔴        |
-| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | 🔴         | ⚫️        | ⚫️        |
+| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | 🟢        | 🟢        | ⚫️          | ⚫️          | 🟢         | ⚫️        | ⚫️        |
 | Wire master                                 | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🟢        | 🔴        |
 | Wire slave                                  | 🟢        | ⚪️        | ⚪️         | 🟢         | 🔴        | 🟢        | ⚪️          | ⚪️          | 🔴         | 🔴        | 🔴        |
 | Neopixel library/libraries                  | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | 🟢         | 🟢        | 🔴        |
@@ -51,7 +51,7 @@ ATtiny167:
 
 ATtiny861:
 
-- SPI master: Message is not received by slave 
+- SPI master: Message is not received by the slave 
 
 ATtiny43U:
 
@@ -61,7 +61,9 @@ ATtiny43U:
 
 ATtiny828:
 
-- <s>Neopixel does not work on: 6,7,8,9,11, ...? Does not work on 1.5.2 either on pin 11, even if I set Neopixel port to PORTB</s>  *was the board hardware* 
-- Wire Master & Salve use apparently my bitbang I2C lib SoftI2CMaster and fail with a compilation error
-- <s>Reading analog values: Wildly wrong and huge differences. Even when measuring individually, the values are way off (with the 1.5.2 core, it is the same; maybe it is a problem with the sample?)  </s> *Was probably the board!*
-- analogWrite: Does not work at all. Under the 1.5.2 core it works for pins 20-22 (but not for 16). This still holds for the new hardware setup.
+- **Note**: When PD3 (D27) is used as an input (also for TWI/SPI slave clock), WDT has to be activated!
+
+- <s>Neopixel does not work on: 6,7,8,9,11, ...? Does not work on 1.5.2 either on pin 11, even if I set Neopixel port to PORTB</s>.  *It was the board hardware*!
+- Wire Master & Slave fail with a compilation error (pins need to be defined in pins_arduino.h)
+- <s>Reading analog values: Wildly wrong and huge differences. Even when measuring individually, the values are way off (with the 1.5.2 core, it is the same; maybe it is a problem with the sample?)  </s> *Was probably the board hardware as well*
+- analogWrite: Does not work at all. This still holds for the new hardware setup. Under the 1.5.2 core it works for pins 20-22 (but not for 16). 

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -6,6 +6,11 @@ The tests in this folder each check one particular basic functionality. They are
 - `analogw`: Tests `analogWrite` on all supported pins, one by one, trying out different values.
 - `analogr`: Tests `analogRead` on all supported pins, one by one, trying 0V and Vcc.
 - `analogv`: Tests `analogRead` on all supported pins in parallel, printing the measured voltage. 
+- `serial`: Tests serial I/O.
+- `wire`: Tests to check I2C master and slave capabilities.
+- `spi`: Tests to check SPI master and slave capabilities.
+- `neo`: Tests to check the neopixel functionality.
+- `servo`: Tests to check servo functionality.
 
 
 
@@ -13,12 +18,12 @@ The tests in this folder each check one particular basic functionality. They are
 | ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
 | `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
-| `Serial.print()` and `Serial.read()`        | ⚪️        | ⚪️        | ⚪️         | 🟢         | 🟡        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
+| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟡        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | ⚪️        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | SPI master                                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | SPI slave                                   | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Wire master                                 | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| Wire slave                                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| Wire slave                                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Neopixel library/libraries                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Servo library/libraries                     | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | ⚪️        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 
@@ -28,11 +33,10 @@ The tests in this folder each check one particular basic functionality. They are
 ⚫️ = Not present
 ⚪️ = Untested
 
-ATtiny26: 
+ATtiny26:
 
 - analogWrite: PWM does not work on either PWM pin (9 and 11)
-- Serial I/O does not compile: ser.ino:19: undefined reference to `\__SP_H__'
 
 ATtinyX7:
 
-- TX works, RX does not
+- Serial: TX works, RX does not

--- a/avr/extras/tests/README.md
+++ b/avr/extras/tests/README.md
@@ -1,6 +1,6 @@
 # Minimum functionality tests
 
-The tests in this folder each check one particular basic functionality. They are organized in folders, where each folder contains at least a target sketch, which needs to be flashed to the target chip, and perhaps a host sketch for an ATmega328P (Uno, Mega, or Nano). Further, there will be a generic description of how to wire up the two sketches and how to run the test protocol. 
+The tests in this folder each check one particular basic functionality. They are organized in folders, where each folder contains at least a target sketch, which needs to be flashed to the target chip, and perhaps a host sketch for an ATmega328P (Uno, Mega, or Nano). Further, there will be a generic description of how to wire up the two boards and how to run the test protocol. 
 
 - `digitalrw`: Tests `digitalRead` and `digitalWrite` on all pins
 - `analogw`: Tests `analogWrite` on all supported pins, one by one, trying out different values.
@@ -18,10 +18,10 @@ The tests in this folder each check one particular basic functionality. They are
 | ------------------------------------------- | -------- | -------- | --------- | --------- | -------- | -------- | ---------- | ---------- | --------- | -------- | -------- |
 | `digitalRead()`/`digitalWrite()`on all pins | 🟢        | 🟢        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogWrite()`on all supported pins        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🔴        |
-| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟡        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
+| `Serial.print()` and `Serial.read()`        | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚪️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | `analogRead()`on all supported pins         | 🟢        | ⚪️        | ⚪️         | 🟢         | 🟢        | 🟢        | ⚫️          | ⚪️          | ⚪️         | 🟢        | 🟢        |
 | SPI master                                  | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
-| SPI slave                                   | 🔴        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
+| SPI slave                                   | ⚫️        | ⚫️        | ⚪️         | ⚫️         | ⚪️        | 🟢        | ⚫️          | ⚫️          | ⚪️         | ⚫️        | ⚫️        |
 | Wire master                                 | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Wire slave                                  | 🟢        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |
 | Neopixel library/libraries                  | ⚪️        | ⚪️        | ⚪️         | ⚪️         | ⚪️        | 🟢        | ⚪️          | ⚪️          | ⚪️         | ⚪️        | ⚪️        |

--- a/avr/extras/tests/analogr/host_analogr/host_analogr.ino
+++ b/avr/extras/tests/analogr/host_analogr/host_analogr.ino
@@ -83,7 +83,7 @@ void loop()
 
 void report_success()
 {
-  Serial.println(F("Analog write test successfully completed!"));
+  Serial.println(F("Analog read test successfully completed!"));
   bool on = false;
   for (int i = 0; i < iocount; i++) pinMode(HPIN(i), INPUT);
   pinMode(LED_BUILTIN, OUTPUT);

--- a/avr/extras/tests/analogr/target_analogr/target_analogr.ino
+++ b/avr/extras/tests/analogr/target_analogr/target_analogr.ino
@@ -6,12 +6,17 @@
 #define ANALOG_HIGH 1008
 
 unsigned long start;
-// number of digital pins without the RESET pin, for ATtinyx8 only the one for the DIP footprint
+// number of digital pins without the RESET pin (usually the pin with the highest number),
+// for ATtinyx8 only the one for the DIP footprint
+// for ATtiny828 only those before the RESET pin
 #if defined(__AVR_ATtiny48__) || defined(__AVR_ATtiny88__)
 const int iopins = 23;
+#elif defined(__AVR_ATtiny828__)
+const int iopins = 26;
 #else
 const int iopins = NUM_DIGITAL_PINS - 1; 
 #endif
+
 int phase;
 int pin = 0;
 volatile int r;

--- a/avr/extras/tests/analogv/anav/anav.ino
+++ b/avr/extras/tests/analogv/anav/anav.ino
@@ -31,6 +31,7 @@ void loop()
   for (pin=0; pin < iopins; pin++) {
     if (digitalPinToAnalogInput(pin) >= 0 && digitalPinToAnalogInput(pin) != NOT_A_PIN) { 
       adc = analogRead(pin);
+      adc = analogRead(pin);
       Serial.print(pin);
       Serial.print(":");
       Serial.print((adc*VCC)/1023);

--- a/avr/extras/tests/analogv/anav/anav.ino
+++ b/avr/extras/tests/analogv/anav/anav.ino
@@ -29,8 +29,7 @@ void loop()
   long adc;
 
   for (pin=0; pin < iopins; pin++) {
-    //if (pin >= 17 && pin <= 22) {
-    if ((((pin) >= 17 && (pin) <= 22) ? ((pin)-17):NOT_A_PIN) != NOT_A_PIN) {
+    if (digitalPinToAnalogInput(pin) >= 0 && digitalPinToAnalogInput(pin) != NOT_A_PIN) { 
       adc = analogRead(pin);
       Serial.print(pin);
       Serial.print(":");

--- a/avr/extras/tests/analogv/anav/anav.ino
+++ b/avr/extras/tests/analogv/anav/anav.ino
@@ -29,8 +29,11 @@ void loop()
   long adc;
 
   for (pin=0; pin < iopins; pin++) {
-    if (digitalPinToAnalogInput(pin) >= 0 && digitalPinToAnalogInput(pin) != NOT_A_PIN) {
+    //if (pin >= 17 && pin <= 22) {
+    if ((((pin) >= 17 && (pin) <= 22) ? ((pin)-17):NOT_A_PIN) != NOT_A_PIN) {
       adc = analogRead(pin);
+      Serial.print(pin);
+      Serial.print(":");
       Serial.print((adc*VCC)/1023);
       Serial.print(" ");
       Serial.flush();

--- a/avr/extras/tests/analogw/target_analogw/target_analogw.ino
+++ b/avr/extras/tests/analogw/target_analogw/target_analogw.ino
@@ -7,7 +7,7 @@
 unsigned long start;
 // number of digital pins without the RESET pin, for ATtinyx8 only the one for the DIP footprint
 #if defined(__AVR_ATtiny48__) || defined(__AVR_ATtiny88__)
-const iopins = 23;
+const int iopins = 23;
 #else
 const int iopins = NUM_DIGITAL_PINS - 1; 
 #endif

--- a/avr/extras/tests/digitalrw/host_digitalrw/host_digitalrw.ino
+++ b/avr/extras/tests/digitalrw/host_digitalrw/host_digitalrw.ino
@@ -58,6 +58,7 @@ void loop()
         Serial.println(i);
         if (lowcount++ > 10) 
           report_failure();
+        delay(1);
         return;
       }
     }

--- a/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
+++ b/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
@@ -25,6 +25,16 @@ void setup()
   start = millis();
 }
 
+int realpin(int pin)
+{
+  // 828 is the only ATtiny that has one pin with a HIGHER number than the RESET pin
+#ifdef __AVR_ATtiny828__ 
+  return ((pin == iopins-1) ? iopins : pin); 
+#else
+  return(pin);
+#endif
+}
+
 void loop()
 {
   int i;
@@ -49,10 +59,10 @@ void loop()
   case 3:
     for (i = 0; i < iopins; i++) {
       if (i == led_builtin) {
-        digitalWrite(i, HIGH);
-        pinMode(i, OUTPUT);
+        digitalWrite(realpin(i), HIGH);
+        pinMode(realpin(i), OUTPUT);
       } else {
-        pinMode(i, INPUT_PULLUP);
+        pinMode(realpin(i), INPUT_PULLUP);
       }
     }
     delay(100);
@@ -61,22 +71,22 @@ void loop()
     break;
   case 4:
     for (i = 0; i < iopins; i++)
-      if (digitalRead(i) == LOW)
+      if (digitalRead(realpin(i)) == LOW)
         report_failure();
     phase = 5;
     start = millis();
     break;
   case 5:
     for (i = 0; i < iopins; i++) {
-      digitalWrite(i, HIGH);
-      pinMode(i, OUTPUT);
+      digitalWrite(realpin(i), HIGH);
+      pinMode(realpin(i), OUTPUT);
     }
     phase = 6;
     start = millis();
     break;
   case 6:
     for (i = 0; i < iopins; i++) {
-      digitalWrite(i, LOW);
+      digitalWrite(realpin(i), LOW);
       delay(200);
     }
     delay(100);
@@ -84,22 +94,22 @@ void loop()
     start = millis();
     break;
   case 7:
-    for (i = 0; i < iopins; i++) pinMode(i, INPUT);
+    for (i = 0; i < iopins; i++) pinMode(realpin(i), INPUT);
     phase = 9;
     subphase = 0;
     start = millis();
     break;
   case 9: /* wait for all pins to come high */
     for (i = 0; i < iopins; i++)
-      if (digitalRead(i) == LOW) return;
+      if (digitalRead(realpin(i)) == LOW) return;
     phase = 10;
     start = millis();
     break;
   case 10: /* Now wait for switching to LOW one by one */
     for (i = 0; i <= subphase; i++) 
-      if (digitalRead(i) == HIGH) return;
+      if (digitalRead(realpin(i)) == HIGH) return;
     for (i = subphase+1; i < iopins; i++)
-      if (digitalRead(i) == LOW) return;
+      if (digitalRead(realpin(i)) == LOW) return;
     subphase++;
     if (subphase >= iopins) {
       subphase = -1;

--- a/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
+++ b/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
@@ -6,7 +6,7 @@
 unsigned long start;
 // number of digital pins without the RESET pin, for ATtinyx8 only the one for the DIP footprint
 #if defined(__AVR_ATtiny48__) || defined(__AVR_ATtiny88__)
-const iopins = 23;
+const int iopins = 23;
 #else
 const int iopins = NUM_DIGITAL_PINS - 1; 
 #endif

--- a/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
+++ b/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
@@ -4,7 +4,8 @@
 #define COMPIN 0
 
 unsigned long start;
-// number of digital pins without the RESET pin, for ATtinyx8 only the one for the DIP footprint
+// number of digital pins without the RESET pin (usually the pin with the highest number),
+// for ATtinyx8 only the one for the DIP footprint
 #if defined(__AVR_ATtiny48__) || defined(__AVR_ATtiny88__)
 const int iopins = 23;
 #else
@@ -130,7 +131,7 @@ void loop()
 
 void report_failure()
 {
-  for (int i = 0; i < iopins; i++) pinMode(i, INPUT);
+  for (int i = 0; i < iopins; i++) pinMode(realpin(i), INPUT);
   while (1);
 }
 

--- a/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
+++ b/avr/extras/tests/digitalrw/target_digitalrw/target_digitalrw.ino
@@ -6,8 +6,11 @@
 unsigned long start;
 // number of digital pins without the RESET pin (usually the pin with the highest number),
 // for ATtinyx8 only the one for the DIP footprint
+// for ATtiny828 only those before the RESET pin
 #if defined(__AVR_ATtiny48__) || defined(__AVR_ATtiny88__)
 const int iopins = 23;
+#elif defined(__AVR_ATtiny828__)
+const int iopins = 26;
 #else
 const int iopins = NUM_DIGITAL_PINS - 1; 
 #endif
@@ -26,15 +29,6 @@ void setup()
   start = millis();
 }
 
-int realpin(int pin)
-{
-  // 828 is the only ATtiny that has one pin with a HIGHER number than the RESET pin
-#ifdef __AVR_ATtiny828__ 
-  return ((pin == iopins-1) ? iopins : pin); 
-#else
-  return(pin);
-#endif
-}
 
 void loop()
 {
@@ -60,10 +54,10 @@ void loop()
   case 3:
     for (i = 0; i < iopins; i++) {
       if (i == led_builtin) {
-        digitalWrite(realpin(i), HIGH);
-        pinMode(realpin(i), OUTPUT);
+        digitalWrite(i, HIGH);
+        pinMode(i, OUTPUT);
       } else {
-        pinMode(realpin(i), INPUT_PULLUP);
+        pinMode(i, INPUT_PULLUP);
       }
     }
     delay(100);
@@ -72,22 +66,22 @@ void loop()
     break;
   case 4:
     for (i = 0; i < iopins; i++)
-      if (digitalRead(realpin(i)) == LOW)
+      if (digitalRead(i) == LOW)
         report_failure();
     phase = 5;
     start = millis();
     break;
   case 5:
     for (i = 0; i < iopins; i++) {
-      digitalWrite(realpin(i), HIGH);
-      pinMode(realpin(i), OUTPUT);
+      digitalWrite(i, HIGH);
+      pinMode(i, OUTPUT);
     }
     phase = 6;
     start = millis();
     break;
   case 6:
     for (i = 0; i < iopins; i++) {
-      digitalWrite(realpin(i), LOW);
+      digitalWrite(i, LOW);
       delay(200);
     }
     delay(100);
@@ -95,22 +89,22 @@ void loop()
     start = millis();
     break;
   case 7:
-    for (i = 0; i < iopins; i++) pinMode(realpin(i), INPUT);
+    for (i = 0; i < iopins; i++) pinMode(i, INPUT);
     phase = 9;
     subphase = 0;
     start = millis();
     break;
   case 9: /* wait for all pins to come high */
     for (i = 0; i < iopins; i++)
-      if (digitalRead(realpin(i)) == LOW) return;
+      if (digitalRead(i) == LOW) return;
     phase = 10;
     start = millis();
     break;
   case 10: /* Now wait for switching to LOW one by one */
     for (i = 0; i <= subphase; i++) 
-      if (digitalRead(realpin(i)) == HIGH) return;
+      if (digitalRead(i) == HIGH) return;
     for (i = subphase+1; i < iopins; i++)
-      if (digitalRead(realpin(i)) == LOW) return;
+      if (digitalRead(i) == LOW) return;
     subphase++;
     if (subphase >= iopins) {
       subphase = -1;
@@ -131,7 +125,7 @@ void loop()
 
 void report_failure()
 {
-  for (int i = 0; i < iopins; i++) pinMode(realpin(i), INPUT);
+  for (int i = 0; i < iopins; i++) pinMode(i, INPUT);
   while (1);
 }
 

--- a/avr/extras/tests/neo/protocol.md
+++ b/avr/extras/tests/neo/protocol.md
@@ -1,0 +1,5 @@
+# Test protocol: Neopixel
+
+This test checks whether the basic Neopixel functionality is
+there. Simply use the `simple` example sketch from the two libraries and
+change PIN and NUMPIXELS accordingly.

--- a/avr/extras/tests/neo/protocol.md
+++ b/avr/extras/tests/neo/protocol.md
@@ -1,5 +1,5 @@
 # Test protocol: Neopixel
 
 This test checks whether the basic Neopixel functionality is
-there. Simply use the `simple` example sketch from the two libraries and
+there. Simply use the `strandtest` example sketch from the two libraries and
 change PIN and NUMPIXELS accordingly.

--- a/avr/extras/tests/serial/protocol.md
+++ b/avr/extras/tests/serial/protocol.md
@@ -4,6 +4,6 @@ This test checks whether the basic serial I/O functionality is there. It outputs
 
 1. Set up the target chip/board on a breadboard. 
 2. Connect the serial lines to a USB/UART converter.
-3. Adjust the compile constants in the sketch. Perhaps you have to tune the OSCCAL value.
+3. Adjust the compile constants in the sketch. Perhaps you have to tune the OSCCAL value (using the tune_osccal sketch).
 4. Flash target sketch
 5. Open a terminal application on your host and connect it with the serial I/O of the target. 

--- a/avr/extras/tests/serial/ser/ser.ino
+++ b/avr/extras/tests/serial/ser/ser.ino
@@ -1,9 +1,12 @@
 // At 8 MHz internal osc., 57600 baud should work for software UART, and 250000 baud should work for hardware UART
-#define BPS 57600
-//#define CORR_OSCCAL 0x70
+#define BPS 9600
+#define CORR_OSCCAL 0x68
 
 void setup() {
-  Serial.begin(57600);
+#ifdef CORR_OSCCAL  
+  OSCCAL = CORR_OSCCAL;
+#endif
+  Serial.begin(BPS);
   Serial.println();
   Serial.println();
   Serial.println("Hello World!");

--- a/avr/extras/tests/serial/ser/ser.ino
+++ b/avr/extras/tests/serial/ser/ser.ino
@@ -1,6 +1,6 @@
 // At 8 MHz internal osc., 57600 baud should work for software UART, and 250000 baud should work for hardware UART
 #define BPS 9600
-#define CORR_OSCCAL 0x68
+//#define CORR_OSCCAL 0x68
 
 void setup() {
 #ifdef CORR_OSCCAL  

--- a/avr/extras/tests/serial/tune_osccal/tune_osccal.ino
+++ b/avr/extras/tests/serial/tune_osccal/tune_osccal.ino
@@ -1,0 +1,17 @@
+
+uint8_t orig_osccal;
+void setup() {
+  Serial.begin(9600);
+  Serial.println("Hello World!");
+  orig_osccal=OSCCAL;
+}
+
+void loop() {
+  while (Serial.available() > 0) {   // Check if data is received
+    uint8_t incomingByte = Serial.read(); // Read one byte
+    Serial.printf("Got char %c and ASCII value %d, orig. OSCCAL: %x, act. OSCCAL: %x\n", incomingByte, incomingByte, orig_osccal, OSCCAL);
+
+    OSCCAL--;
+  }
+  delay(1000);
+}

--- a/avr/extras/tests/servo/protocol.md
+++ b/avr/extras/tests/servo/protocol.md
@@ -1,0 +1,4 @@
+# Test protocol: Servo
+
+This test checks whether the basic Servo functionality is
+there. Simply use the `sweep.ino` example sketch.

--- a/avr/extras/tests/spi/mspi/mspi.ino
+++ b/avr/extras/tests/spi/mspi/mspi.ino
@@ -1,0 +1,41 @@
+// Master SPI sketch: Send 'hello slave' and receive 'hi master'
+#include <SPI.h>
+
+#define TXBIT 4
+
+const int len = 12;
+char send[12] = "hello slave";
+char succ[12] = "success";
+char recv[12] = "hi master";
+char buf[12];
+
+void setup (void) {
+   //Serial.setTxBit(4);
+   Serial.begin(9600); //set baud
+   Serial.println(F("\n\r\n\rSPI Master test sketch"));
+   digitalWrite(SS, HIGH); // disable Slave Select
+   SPI.begin ();
+   SPI.setClockDivider(SPI_CLOCK_DIV8);//divide the clock by 8
+}
+
+void loop (void) {
+   int i;
+   char c;
+   digitalWrite(SS, LOW); // enable Slave Select
+   // send test string
+   Serial.println(F("Sending: 'hello slave'"));
+   for (i=0; i < len; i++) {
+      c = SPI.transfer (send[i]);
+      delayMicroseconds(10);
+      if (i > 0) buf[i-1] = c; 
+   }
+   Serial.println();
+   Serial.print(F("Received: "));
+   Serial.println(buf);
+   digitalWrite(SS, HIGH); // disable Slave Select
+   if (strcmp(recv, buf) == 0)
+     Serial.println(F("SPI test successful"));
+   else
+     Serial.println(F("SPI test failed"));
+   while (1);
+}

--- a/avr/extras/tests/spi/mspi/mspi.ino
+++ b/avr/extras/tests/spi/mspi/mspi.ino
@@ -11,7 +11,7 @@ char buf[12];
 
 void setup (void) {
    //Serial.setTxBit(4);
-   Serial.begin(57600); //set baud
+   Serial.begin(9600); //set baud
    Serial.println(F("\n\r\n\rSPI Master test sketch"));
    digitalWrite(SS, HIGH); // disable Slave Select
    SPI.begin ();

--- a/avr/extras/tests/spi/mspi/mspi.ino
+++ b/avr/extras/tests/spi/mspi/mspi.ino
@@ -11,7 +11,7 @@ char buf[12];
 
 void setup (void) {
    //Serial.setTxBit(4);
-   Serial.begin(9600); //set baud
+   Serial.begin(57600); //set baud
    Serial.println(F("\n\r\n\rSPI Master test sketch"));
    digitalWrite(SS, HIGH); // disable Slave Select
    SPI.begin ();

--- a/avr/extras/tests/spi/sspi/sspi.ino
+++ b/avr/extras/tests/spi/sspi/sspi.ino
@@ -1,0 +1,46 @@
+// Slave SPI sketch: Receive 'hello slave' and send 'hi master'
+// terminate when first null byte comes in and the start over
+#include <SPI.h>
+volatile byte indx;
+volatile boolean done;
+
+const int len = 12;
+char recv[12] = "hello slave";
+char send[12] = "hi master";
+char buf[12];
+bool success = false;
+
+void setup (void) {
+   Serial.begin (9600);
+   Serial.println(F("\n\r\n\rSPI Slave test sketch"));
+   pinMode(MISO, OUTPUT); // have to send on master in so it set as output
+   SPCR |= _BV(SPE); // turn on SPI in slave mode
+   indx = 0; // buffer empty
+   done = false;
+   SPI.attachInterrupt(); // turn on interrupt
+}
+
+ISR (SPI_STC_vect) // SPI interrupt routine 
+{ 
+   byte c = SPDR; // read byte from SPI Data Register
+   if (indx < sizeof buf) {
+      buf[indx] = c; // save data in the next index in the array buff
+      if (c == '\0') //check for the end of the word
+        done = true;
+      SPDR = send[indx++]; // reply string
+   }
+}
+
+void loop (void) {
+  if (done) {
+    Serial.print(F("Received: '"));
+    Serial.print(buf); 
+    Serial.println(F("'"));
+    if (strcmp(recv, buf) == 0) 
+      Serial.println(F("SPI test successful"));
+    else
+      Serial.println(F("SPI test failed"));
+    indx = 0; 
+    done = false; //reset the process   
+  }
+}

--- a/avr/extras/tests/spi/sspi/sspi.ino
+++ b/avr/extras/tests/spi/sspi/sspi.ino
@@ -4,6 +4,18 @@
 volatile byte indx;
 volatile boolean done;
 
+#ifdef __AVR_ATtiny828__
+#include <avr/wdt.h>
+// The ATtiny828 SPI slave works only if WDT is active
+// wdt is disabled initially in order to avoid wdt loops!
+void wdt_init(void) __attribute__((naked)) __attribute__((section(".init3"))) __attribute__((used));
+void wdt_init(void)
+{
+  MCUSR = 0;
+  wdt_disable();
+}
+#endif
+
 const int len = 12;
 char recv[12] = "hello slave";
 char send[12] = "hi master";
@@ -11,6 +23,9 @@ char buf[12];
 bool success = false;
 
 void setup (void) {
+#ifdef __AVR_ATtiny828__
+   wdt_enable(WDTO_8S);
+#endif
    Serial.begin (9600);
    Serial.println(F("\n\r\n\rSPI Slave test sketch"));
    pinMode(MISO, OUTPUT); // have to send on master in so it set as output

--- a/avr/extras/tests/wire/mwire/mwire.ino
+++ b/avr/extras/tests/wire/mwire/mwire.ino
@@ -54,9 +54,9 @@ void loop() {
     strcpy(buf,"END2");
   if (buf[3]++ == '3') {
     if (succ)
-      Serial.println(F("Wire master test successfull"));
+      Serial.println(F("Wire test successfull"));
     else
-      Serial.println("*** Wire master test failed");
+      Serial.println("*** Wire test failed");
     while(1);
   }
 }

--- a/avr/extras/tests/wire/mwire/mwire.ino
+++ b/avr/extras/tests/wire/mwire/mwire.ino
@@ -1,6 +1,6 @@
 // Write a value to the slave, then read it again
 #define I2CADDR 8 
-#define STRINGIFY(x) #x
+#define IASTR "8"
 
 #include <Wire.h>
 
@@ -12,7 +12,7 @@ void setup() {
   Serial.println(F("\n\r\n\rWire Master test"));
   Wire.begin(); // join I2C bus (address optional for master)
   while (1) {
-    Serial.println(F("Checking for I2C slave at addr " STRINGIFY(I2CADDR)));
+    Serial.println(F("Checking for I2C slave at addr " IASTR));
     Wire.beginTransmission(I2CADDR);
     byte error = Wire.endTransmission();
     if (error == 0) break;

--- a/avr/extras/tests/wire/mwire/mwire.ino
+++ b/avr/extras/tests/wire/mwire/mwire.ino
@@ -1,0 +1,62 @@
+// Write a value to the slave, then read it again
+#define I2CADDR 8 
+#define STRINGIFY(x) #x
+
+#include <Wire.h>
+
+bool succ = true;
+char buf[5] = "MES0";
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println(F("\n\r\n\rWire Master test"));
+  Wire.begin(); // join I2C bus (address optional for master)
+  while (1) {
+    Serial.println(F("Checking for I2C slave at addr " STRINGIFY(I2CADDR)));
+    Wire.beginTransmission(I2CADDR);
+    byte error = Wire.endTransmission();
+    if (error == 0) break;
+    delay(1500);
+  }
+  Serial.println(F("Slave device located"));
+}
+
+void loop() {
+  int i;
+  Serial.print(F("Sending ")); Serial.println(buf);
+  Wire.beginTransmission(I2CADDR); // transmit to device #8
+  Wire.write(buf);             // sends four bytes
+  if (Wire.endTransmission() != 0) {  // stop transmitting
+    succ = false;
+    Serial.println(F("*** Sending failed"));
+  }
+  delay(100);
+  Serial.println(F("Requesting 4 bytes"));
+  Serial.print(F("Receiving: "));
+  Wire.requestFrom(I2CADDR, 4);    // request 6 bytes from slave device #8
+  i = 0;
+  while (Wire.available()) { // slave may send less than requested
+    char c = Wire.read(); // receive a byte as character
+    Serial.print(c);         // print the character
+    if (c != buf[i]) {
+      succ = false;
+      Serial.println(F("*** Received byte wrong"));
+    }
+    if (i == 4) {
+      succ = false;
+      Serial.println(F("*** Too many bytes"));
+    }
+    i++;      
+  }
+  Serial.println();
+  delay(500);
+  if (strcmp(buf,"MES2") == 0)
+    strcpy(buf,"END2");
+  if (buf[3]++ == '3') {
+    if (succ)
+      Serial.println(F("Wire master test successfull"));
+    else
+      Serial.println("*** Wire master test failed");
+    while(1);
+  }
+}

--- a/avr/extras/tests/wire/protocol.md
+++ b/avr/extras/tests/wire/protocol.md
@@ -1,0 +1,11 @@
+# Test protocol: I2C/TWI
+
+This test checks whether the basic I2C functionality is there. It consists of a master sketch (`mwire.ino`) and a slave sketch (`swire.ino`).
+
+1. Set up the target and the host (e.g., Uno or Nano) chips/boards on a breadboard. 
+2. Connect the SDA and SCL lines. Insert also pull-up resistors.
+3. Connect the serial line of one or both of the boards to the PC.
+4. Flash the slave sketch to the target board and the master sketch to the host board.
+5. Start the test by pressing reset on the board with the master sketch.
+6. Success should be reported on both ends.
+7. Repeat the test with master and slave roles exchanged.

--- a/avr/extras/tests/wire/swire/swire.ino
+++ b/avr/extras/tests/wire/swire/swire.ino
@@ -41,6 +41,6 @@ void requestEvent() {
   Wire.write(buf); // respond with message of 4 bytes
                    // as expected by master
   if (strcmp(buf,"END3") == 0) {
-    Serial.println(F("Wire slave test successful"));
+    Serial.println(F("Wire test successful"));
   }
 }

--- a/avr/extras/tests/wire/swire/swire.ino
+++ b/avr/extras/tests/wire/swire/swire.ino
@@ -12,6 +12,7 @@ void setup() {
   Wire.onReceive(receiveEvent); // register event
   Wire.onRequest(requestEvent);
   Serial.begin(9600);           // start serial for output
+  Serial.println(F("\n\rWire slave test"));
 }
 
 void loop() {

--- a/avr/extras/tests/wire/swire/swire.ino
+++ b/avr/extras/tests/wire/swire/swire.ino
@@ -1,7 +1,7 @@
 //Write slave: receive from master and mirror it back.
 
 #define I2CADDR 8 
-#define STRINGIFY(x) #x
+#define IASTR "8"
 
 #include <Wire.h>
 

--- a/avr/extras/tests/wire/swire/swire.ino
+++ b/avr/extras/tests/wire/swire/swire.ino
@@ -1,0 +1,46 @@
+//Write slave: receive from master and mirror it back.
+
+#define I2CADDR 8 
+#define STRINGIFY(x) #x
+
+#include <Wire.h>
+
+char buf[10];
+
+void setup() {
+  Wire.begin(I2CADDR);          // join I2C bus with address #8
+  Wire.onReceive(receiveEvent); // register event
+  Wire.onRequest(requestEvent);
+  Serial.begin(9600);           // start serial for output
+}
+
+void loop() {
+  delay(10);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+void receiveEvent(int howMany) {
+  int i = 0;
+  Serial.print(F("Received: "));
+  while (Wire.available()) { // loop through all but the last
+    char c = Wire.read(); // receive byte as a character
+    Serial.print(c);         // print the character
+    buf[i++] = c;
+  }
+  Serial.println();         // print the integer
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  buf[4] = '\0';
+  Serial.print("Replying to master: '");
+  Serial.print(buf);
+  Serial.println("'");
+  Wire.write(buf); // respond with message of 4 bytes
+                   // as expected by master
+  if (strcmp(buf,"END3") == 0) {
+    Serial.println(F("Wire slave test successful"));
+  }
+}


### PR DESCRIPTION
We now have basically all test procedures.

With SPI, I am a bit unhappy. It works for ATTinys with SPI hardware. However, for USI-based SPI implementations, there seem to be problems. With ATmega328P and ATtiny88, it works flawlessly. For an ATtiny85, the master sketch does not work, and the slave does not compile. The latter is no surprise because the specific SPI registers are missing. However, how do we implement a USI-based slave?