### PR TITLE
Computing flash size correctly 

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -116,7 +116,7 @@ recipe.size.regex=^(?:\.text|\.data|\.bootloader)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 recipe.advanced_size.pattern="/bin/bash" "{runtime.platform.path}/scripts/size.sh" "{compiler.path}{compiler.size.cmd}" "{build.path}/{build.project_name}.elf" "{upload.maximum_size}" "{upload.maximum_data_size}"  "{tools.avrdude.cmd.path}" "{tools.avrdude.config.path}" "{build.mcu}" "{bootloader.str}"
-recipe.advanced_size.pattern.windows="{runtime.platform.path}\scripts\size.bat" "{compiler.path}{compiler.size.cmd}" "{build.path}\{build.project_name}.elf" "{upload.maximum_size}" "{upload.maximum_data_size}"  "{tools.avrdude.cmd.path}" "{tools.avrdude.config.path}" "{build.mcu}" "{bootloader.str}"
+recipe.advanced_size.pattern.windows="{runtime.platform.path}\scripts\size.bat" "{compiler.path}{compiler.size.cmd}.exe" "{build.path}\{build.project_name}.elf" "{upload.maximum_size}" "{upload.maximum_data_size}"  "{tools.avrdude.cmd.path}" "{tools.avrdude.config.path}" "{build.mcu}" "{bootloader.str}"
 
 ## Preprocessor
 preproc.includes.flags=-w -x c++ -M -MG -MP

--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -115,6 +115,8 @@ recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build
 recipe.size.regex=^(?:\.text|\.data|\.bootloader)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
+recipe.advanced_size.pattern="/bin/bash" "{runtime.platform.path}/scripts/size.sh" "{compiler.path}{compiler.size.cmd}" "{build.path}/{build.project_name}.elf" "{upload.maximum_size}" "{upload.maximum_data_size}"  "{tools.avrdude.cmd.path}" "{tools.avrdude.config.path}" "{build.mcu}" "{bootloader.str}"
+recipe.advanced_size.pattern.windows="{runtime.platform.path}\scripts\size.bat" "{compiler.path}{compiler.size.cmd}" "{build.path}\{build.project_name}.elf" "{upload.maximum_size}" "{upload.maximum_data_size}"  "{tools.avrdude.cmd.path}" "{tools.avrdude.config.path}" "{build.mcu}" "{bootloader.str}"
 
 ## Preprocessor
 preproc.includes.flags=-w -x c++ -M -MG -MP

--- a/avr/scripts/size.bat
+++ b/avr/scripts/size.bat
@@ -24,10 +24,11 @@ if "%bootname%"=="" (
 REM Calculate maxflash
 set /a maxflash=%maxflash% - %boot%
 
+
 REM Calculate flash and RAM from avr-size output
 set flash=0
 set ram=0
-for /f "tokens=1,2" %%a in ('"%sizeprog%" -A "%sketch%"') do (
+for /f "tokens=1,2" %%a in ('%sizeprog% -A %sketch%') do (
     if "%%a"==".text"   set /a flash+=%%b
     if "%%a"==".data"   set /a flash+=%%b
     if "%%a"==".data"   set /a ram+=%%b

--- a/avr/scripts/size.bat
+++ b/avr/scripts/size.bat
@@ -1,0 +1,68 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Argumente
+set sizeprog=%1
+set sketch=%2
+set maxflash=%3
+set maxram=%4
+set avrdude=%5
+set config=%6
+set mcu=%7
+set bootname=%8
+
+REM Bootloader-Größe bestimmen
+if "%bootname%"=="" (
+    set boot=0
+) else (
+    for /f "tokens=2" %%a in ('%avrdude% -c dryrun -p %mcu% -C %config% %bootname% -qq 2^>nul') do (
+        set boot=%%a
+    )
+    if not defined boot (
+        set boot=256
+    )
+)
+echo %boot%
+
+REM maxflash berechnen
+set /a maxflash=%maxflash% - %boot%
+
+REM Flash berechnen
+set flash=0
+for /f "tokens=1,2" %%a in ('%sizeprog% -A %sketch% ^| findstr /r "^\.text ^\.data"') do (
+    set /a flash+=%%b
+)
+
+REM RAM berechnen
+set ram=0
+for /f "tokens=1,2" %%a in ('%sizeprog% -A %sketch% ^| findstr /r "^\.data ^\.bss ^\.noinit"') do (
+    set /a ram+=%%b
+)
+
+REM Prozent berechnen
+set /a flashpercent=flash*100/maxflash
+
+REM Ausgabe starten
+<nul set /p="{
+  "output": "Flash memory used: %flash% bytes of out of %maxflash% (%flashpercent%%%).
+"
+
+<nul set /p="RAM used for global variables: %ram% bytes out of %maxram%. %avrdude% %config% %mcu% %bootname%","
+
+REM Severity
+if %ram% GTR %maxram% (
+    set severity=error
+) else if %flash% GTR %maxflash% (
+    set severity=error
+) else (
+    set severity=info
+)
+
+<nul set /p=""severity": "%severity%","
+
+REM Sections
+echo "sections": [
+    { "name": "text", "size": %flash%, "max_size": %maxflash% },
+    { "name": "data", "size": %ram%, "max_size": %maxram% }
+  ]
+}

--- a/avr/scripts/size.bat
+++ b/avr/scripts/size.bat
@@ -1,68 +1,47 @@
 @echo off
 setlocal enabledelayedexpansion
 
-REM Argumente
-set sizeprog=%1
-set sketch=%2
-set maxflash=%3
-set maxram=%4
-set avrdude=%5
-set config=%6
-set mcu=%7
-set bootname=%8
+REM Arguments - strip surrounding quotes so paths with spaces work in sub-commands
+set "sizeprog=%~1"
+set "sketch=%~2"
+set "maxflash=%~3"
+set "maxram=%~4"
+set "avrdude=%~5"
+set "config=%~6"
+set "mcu=%~7"
+set "bootname=%~8"
 
-REM Bootloader-Größe bestimmen
+REM Determine bootloader size
 if "%bootname%"=="" (
     set boot=0
 ) else (
-    for /f "tokens=2" %%a in ('%avrdude% -c dryrun -p %mcu% -C %config% %bootname% -qq 2^>nul') do (
+    for /f "tokens=2" %%a in ('"%avrdude%" -c dryrun -p %mcu% -C "%config%" "%bootname%" -qq 2^>nul') do (
         set boot=%%a
     )
-    if not defined boot (
-        set boot=256
-    )
+    if not defined boot set boot=256
 )
-echo %boot%
 
-REM maxflash berechnen
+REM Calculate maxflash
 set /a maxflash=%maxflash% - %boot%
 
-REM Flash berechnen
+REM Calculate flash and RAM from avr-size output
 set flash=0
-for /f "tokens=1,2" %%a in ('%sizeprog% -A %sketch% ^| findstr /r "^\.text ^\.data"') do (
-    set /a flash+=%%b
-)
-
-REM RAM berechnen
 set ram=0
-for /f "tokens=1,2" %%a in ('%sizeprog% -A %sketch% ^| findstr /r "^\.data ^\.bss ^\.noinit"') do (
-    set /a ram+=%%b
+for /f "tokens=1,2" %%a in ('"%sizeprog%" -A "%sketch%"') do (
+    if "%%a"==".text"   set /a flash+=%%b
+    if "%%a"==".data"   set /a flash+=%%b
+    if "%%a"==".data"   set /a ram+=%%b
+    if "%%a"==".bss"    set /a ram+=%%b
+    if "%%a"==".noinit" set /a ram+=%%b
 )
 
-REM Prozent berechnen
+REM Calculate percentage
 set /a flashpercent=flash*100/maxflash
 
-REM Ausgabe starten
-<nul set /p="{
-  "output": "Flash memory used: %flash% bytes of out of %maxflash% (%flashpercent%%%).
-"
+REM Determine severity
+set severity=info
+if %ram% GTR %maxram% set severity=error
+if %flash% GTR %maxflash% set severity=error
 
-<nul set /p="RAM used for global variables: %ram% bytes out of %maxram%. %avrdude% %config% %mcu% %bootname%","
-
-REM Severity
-if %ram% GTR %maxram% (
-    set severity=error
-) else if %flash% GTR %maxflash% (
-    set severity=error
-) else (
-    set severity=info
-)
-
-<nul set /p=""severity": "%severity%","
-
-REM Sections
-echo "sections": [
-    { "name": "text", "size": %flash%, "max_size": %maxflash% },
-    { "name": "data", "size": %ram%, "max_size": %maxram% }
-  ]
-}
+REM Output JSON
+echo {"output": "Flash memory used: %flash% bytes out of %maxflash% (%flashpercent%%%). RAM used for global variables: %ram% bytes out of %maxram%.","severity": "%severity%","sections": [{"name": "text","size": %flash%,"max_size": %maxflash%},{"name": "data","size": %ram%,"max_size": %maxram%}]}

--- a/avr/scripts/size.sh
+++ b/avr/scripts/size.sh
@@ -21,7 +21,7 @@ maxram=$4
 flash=`$1 -A $2 | egrep  '^(.text|.data)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
 ram=`$1 -A $2 | egrep  '^(.data|.bss|.noinit)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
 flashpercent=$((flash*100/maxflash))
-printf  '{  "output": "Flash memory used: %d bytes of out of %d (%d%%). ' $flash $maxflash $flashpercent
+printf  '{  "output": "Flash memory used: %d bytes out of %d (%d%%). ' $flash $maxflash $flashpercent
 printf  'RAM used for global variables: %d bytes out of %d. %s %s %s %s",' $ram $maxram $5 $6 $7 $8
 if [[ $ram -gt $maxram ]] || [[ $flash -gt $maxflash ]]; then
     printf '"severity": "error",'

--- a/avr/scripts/size.sh
+++ b/avr/scripts/size.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# 1st arg: size program
+# 2nd arg: sketch
+# 3rd arg: max flash
+# 4th arg: max ram
+# 5th arg: avrdude path
+# 6th arg: config path
+# 7th arg: MCU
+# 8th arg: bootload name (if any)
+if [[ -z "$8" ]]; then
+    boot=0
+else
+    if [[ `$5 -c dryrun -p $7 -C $6 $8 -qq 2>/dev/null` ]]; then
+        boot=`$5 -c dryrun -p $7 -C $6 $8 -qq | awk '{print $2}'`
+    else
+        boot=256
+    fi
+fi
+maxflash=$(($3-$boot))
+maxram=$4
+flash=`$1 -A $2 | egrep  '^(.text|.data)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
+ram=`$1 -A $2 | egrep  '^(.data|.bss|.noinit)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
+flashpercent=$((flash*100/maxflash))
+printf  '{  "output": "Flash memory used: %d bytes of out of %d (%d%%). ' $flash $maxflash $flashpercent
+printf  'RAM used for global variables: %d bytes out of %d. %s %s %s %s",' $ram $maxram $5 $6 $7 $8
+if [[ $ram -gt $maxram ]] || [[ $flash -gt $maxflash ]]; then
+    printf '"severity": "error",'
+else
+    printf '"severity": "info",'
+fi
+printf '"sections": [    { "name": "text", "size": %d, "max_size": %d },' $flash $maxflash 
+printf '{ "name": "data", "size": %d, "max_size": %d }  ]}' $ram $maxram


### PR DESCRIPTION
I use the `recipe.advanced_size.pattern` to call the newly written `size.sh` script, which deducts the bootloader size from the flash size. 

I used ChatGPT and Co-Pilot to help me write the equivalent Windows batch script (I am really bad in this area). They are also not stellar, but better than I am. 

I've tested it under macOS and Windows. 

BTW: Don't you need that for MiniCore and company as well?