### PR TITLE
size script fix

### DIFF
--- a/avr/scripts/size.sh
+++ b/avr/scripts/size.sh
@@ -22,7 +22,7 @@ flash=`$1 -A $2 | egrep  '^(.text|.data)\s+([0-9]+).*' | awk '{s+=$2}END{print s
 ram=`$1 -A $2 | egrep  '^(.data|.bss|.noinit)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
 flashpercent=$((flash*100/maxflash))
 printf  '{  "output": "Flash memory used: %d bytes out of %d (%d%%). ' $flash $maxflash $flashpercent
-printf  'RAM used for global variables: %d bytes out of %d. %s %s %s %s",' $ram $maxram $5 $6 $7 $8
+printf  'RAM used for global variables: %d bytes out of %d.",' $ram $maxram 
 if [[ $ram -gt $maxram ]] || [[ $flash -gt $maxflash ]]; then
     printf '"severity": "error",'
 else


### PR DESCRIPTION
This PR removes the debug output in the `size.sh` script.

Concerning the IDE 1.8.19: It does not use arduino-cli, but arduino-builder. Thus, it cannot handle the new recipe type. However, it uses the fall-back. 