### PR TITLE
Serial fix

### DIFF
--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -59,8 +59,22 @@
   }
   #endif
 
+// Interrupt handler //////////////////////////////////////////////////////////////
 
-  // Public Methods //////////////////////////////////////////////////////////////
+void HardwareSerial::_tx_udr_empty_irq(void)
+{
+  if (_tx_buffer->head == _tx_buffer->tail) {
+    // Buffer empty, so disable interrupts
+    *_ucsrb &= ~(1 << UDRIE);
+  } else {
+    // There is more data in the output buffer. Send the next byte
+    unsigned char c = _tx_buffer->buffer[_tx_buffer->tail];
+    _tx_buffer->tail = (_tx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
+    *_udr = c;
+  }
+}
+
+// Public Methods //////////////////////////////////////////////////////////////
 
   void HardwareSerial::begin(long baud) {
   #if (defined(UBRR0H) || defined(UBRR1H))
@@ -159,8 +173,16 @@
   }
 
   void HardwareSerial::flush() {
-    while (_tx_buffer->head != _tx_buffer->tail)
-      ;
+    while (_tx_buffer->head != _tx_buffer->tail || (bit_is_set(*_ucsra, UDRIE))) {
+      if (bit_is_clear(SREG, SREG_I) && bit_is_set(*_ucsrb, UDRIE))
+        // Interrupts are globally disabled, but the DR empty
+        // interrupt should be enabled, so poll the DR empty flag to
+        // prevent deadlock
+        if (bit_is_set(*_ucsra, UDRE))
+            _tx_udr_empty_irq();
+      // If interrupts are enabled, the buffer will be emptied in an interrupt driven way
+    }
+    // buffer is empty now
   }
 
   size_t HardwareSerial::write(uint8_t c) {
@@ -168,9 +190,16 @@
 
     // If the output buffer is full, there's nothing for it other than to
     // wait for the interrupt handler to empty it a bit
-    // ???: return 0 here instead?
-    while (i == _tx_buffer->tail)
-      ;
+    while (i == _tx_buffer->tail) {
+      if (bit_is_clear(SREG, SREG_I)) {
+        // Interrupts are disabled, so we'll have to poll the data
+        // register empty flag ourselves. If it is set, pretend an
+        // interrupt has happened and call the handler to free up
+        // space for us.
+        if(bit_is_set(*_ucsra, UDRE))
+          _tx_udr_empty_irq();
+      }
+    }
 
     _tx_buffer->buffer[_tx_buffer->head] = c;
     _tx_buffer->head = i;

--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -39,13 +39,11 @@
 
   // Constructors ////////////////////////////////////////////////////////////////
 
-  HardwareSerial::HardwareSerial(ring_buffer *rx_buffer, ring_buffer *tx_buffer
+  HardwareSerial::HardwareSerial(
   #if ( defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H))
-    ,volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
+    volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
     volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
     volatile uint8_t *udr) {
-    _rx_buffer = rx_buffer;
-    _tx_buffer = tx_buffer;
     _ubrrh = ubrrh;
     _ubrrl = ubrrl;
     _ucsra = ucsra;
@@ -59,20 +57,33 @@
   }
   #endif
 
-// Interrupt handler //////////////////////////////////////////////////////////////
+// Interrupt handler helpers //////////////////////////////////////////////////////////////
 
-void HardwareSerial::_tx_udr_empty_irq(void)
-{
-  if (_tx_buffer->head == _tx_buffer->tail) {
-    // Buffer empty, so disable interrupts
-    *_ucsrb &= ~(1 << UDRIE);
-  } else {
-    // There is more data in the output buffer. Send the next byte
-    unsigned char c = _tx_buffer->buffer[_tx_buffer->tail];
-    _tx_buffer->tail = (_tx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
-    *_udr = c;
+  void HardwareSerial::_tx_udr_empty_irq(void)
+  {
+    if (_tx_buffer_head == _tx_buffer_tail) {
+      // Buffer empty, so disable interrupts
+      *_ucsrb &= ~(1 << UDRIE);
+    } else {
+      // There is more data in the output buffer. Send the next byte
+      unsigned char c = _tx_buffer[_tx_buffer_tail];
+      _tx_buffer_tail = (_tx_buffer_tail + 1) % SERIAL_BUFFER_SIZE;
+      *_udr = c;
+    }
   }
-}
+
+  void HardwareSerial::_store_rx_char(unsigned char c) {
+    byte i = (_rx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
+
+    // if we should be storing the received character into the location
+    // just before the tail (meaning that the head would advance to the
+    // current location of the tail), we're about to overflow the buffer
+    // and so we don't write the character or advance the head.
+    if (i != _rx_buffer_tail) {
+      _rx_buffer[_rx_buffer_head] = c;
+      _rx_buffer_head = i;
+    }
+  }
 
 // Public Methods //////////////////////////////////////////////////////////////
 
@@ -121,9 +132,8 @@ void HardwareSerial::_tx_udr_empty_irq(void)
   }
 
   void HardwareSerial::end() {
-    while (_tx_buffer->head != _tx_buffer->tail) {
-      ; // wait for buffer to end.
-    }
+    flush();
+    
     #if (defined(UBRR0H) || defined(UBRR1H))
      /*
       cbi(*_ucsrb, _rxen);
@@ -146,34 +156,34 @@ void HardwareSerial::_tx_udr_empty_irq(void)
 
 
     #endif
-    _rx_buffer->head = _rx_buffer->tail;
+      // _rx_buffer_head = _rx_buffer_tail; // This is true after flush anyways
   }
 
   int HardwareSerial::available(void) {
-    return (unsigned int)(SERIAL_BUFFER_SIZE + _rx_buffer->head - _rx_buffer->tail) & (SERIAL_BUFFER_SIZE - 1);
+    return (unsigned int)(SERIAL_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail) & (SERIAL_BUFFER_SIZE - 1);
   }
 
   int HardwareSerial::peek(void) {
-    if (_rx_buffer->head == _rx_buffer->tail) {
+    if (_rx_buffer_head == _rx_buffer_tail) {
       return -1;
     } else {
-      return _rx_buffer->buffer[_rx_buffer->tail];
+      return _rx_buffer[_rx_buffer_tail];
     }
   }
 
   int HardwareSerial::read(void) {
     // if the head isn't ahead of the tail, we don't have any characters
-    if (_rx_buffer->head == _rx_buffer->tail) {
+    if (_rx_buffer_head == _rx_buffer_tail) {
       return -1;
     } else {
-      unsigned char c = _rx_buffer->buffer[_rx_buffer->tail];
-      _rx_buffer->tail = (_rx_buffer->tail + 1)  & (SERIAL_BUFFER_SIZE - 1);
+      unsigned char c = _rx_buffer[_rx_buffer_tail];
+      _rx_buffer_tail = (_rx_buffer_tail + 1)  & (SERIAL_BUFFER_SIZE - 1);
       return c;
     }
   }
 
   void HardwareSerial::flush() {
-    while (_tx_buffer->head != _tx_buffer->tail || (bit_is_set(*_ucsra, UDRIE))) {
+    while (_tx_buffer_head != _tx_buffer_tail || (bit_is_set(*_ucsra, UDRIE))) {
       if (bit_is_clear(SREG, SREG_I) && bit_is_set(*_ucsrb, UDRIE))
         // Interrupts are globally disabled, but the DR empty
         // interrupt should be enabled, so poll the DR empty flag to
@@ -186,11 +196,11 @@ void HardwareSerial::_tx_udr_empty_irq(void)
   }
 
   size_t HardwareSerial::write(uint8_t c) {
-    byte i = (_tx_buffer->head + 1)  & (SERIAL_BUFFER_SIZE - 1);
+    byte i = (_tx_buffer_head + 1)  & (SERIAL_BUFFER_SIZE - 1);
 
     // If the output buffer is full, there's nothing for it other than to
     // wait for the interrupt handler to empty it a bit
-    while (i == _tx_buffer->tail) {
+    while (i == _tx_buffer_tail) {
       if (bit_is_clear(SREG, SREG_I)) {
         // Interrupts are disabled, so we'll have to poll the data
         // register empty flag ourselves. If it is set, pretend an
@@ -201,8 +211,8 @@ void HardwareSerial::_tx_udr_empty_irq(void)
       }
     }
 
-    _tx_buffer->buffer[_tx_buffer->head] = c;
-    _tx_buffer->head = i;
+    _tx_buffer[_tx_buffer_head] = c;
+    _tx_buffer_head = i;
 
     #if (defined(UBRR0H) || defined(UBRR1H) )
       *_ucsrb |= _udrie;
@@ -210,8 +220,8 @@ void HardwareSerial::_tx_udr_empty_irq(void)
       if(!(LINENIR & _BV(LENTXOK))){
         // The buffer was previously empty, so load the first byte, then enable 
         // the TX Complete interrupt
-        unsigned char c = _tx_buffer->buffer[_tx_buffer->tail];
-        _tx_buffer->tail = (_tx_buffer->tail + 1) & (SERIAL_BUFFER_SIZE - 1);
+        unsigned char c = _tx_buffer[_tx_buffer_tail];
+        _tx_buffer_tail = (_tx_buffer_tail + 1) & (SERIAL_BUFFER_SIZE - 1);
         LINDAT = c;
         LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
       }

--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -52,23 +52,29 @@
   }
   #else
   ) {
-    _rx_buffer = rx_buffer;
-    _tx_buffer = tx_buffer;
   }
   #endif
 
 // Interrupt handler helpers //////////////////////////////////////////////////////////////
 
-  void HardwareSerial::_tx_udr_empty_irq(void)
+  void HardwareSerial::_tx_reg_empty_irq(void)
   {
     if (_tx_buffer_head == _tx_buffer_tail) {
       // Buffer empty, so disable interrupts
-      *_ucsrb &= ~(1 << UDRIE);
+#ifdef LINENIR
+      LINENIR &= ~(1 << LENTXOK); //unset LENTXOK
+#else
+      *_ucsrb &= ~(1 << UDRIE); // disable data ready irq
+#endif
     } else {
       // There is more data in the output buffer. Send the next byte
       unsigned char c = _tx_buffer[_tx_buffer_tail];
       _tx_buffer_tail = (_tx_buffer_tail + 1) % SERIAL_BUFFER_SIZE;
+#ifdef LINDAT
+      LINDAT = c;
+#else
       *_udr = c;
+#endif
     }
   }
 
@@ -183,13 +189,22 @@
   }
 
   void HardwareSerial::flush() {
-    while (_tx_buffer_head != _tx_buffer_tail || (bit_is_set(*_ucsra, UDRIE))) {
+#ifdef LINENIR
+    while (_tx_buffer_head != _tx_buffer_tail || (bit_is_set(LINENIR, LENTXOK))) {
+      if (bit_is_clear(SREG, SREG_I) && bit_is_set(LINENIR, LENTXOK))
+        // Interrupts are globally disabled, but the DR empty
+        // interrupt should be enabled, so poll the DR empty flag to
+        // prevent deadlock
+        if (bit_is_set(LINSIR, LTXOK))
+#else
+    while (_tx_buffer_head != _tx_buffer_tail || (bit_is_set(*_ucsrb, UDRIE))) {
       if (bit_is_clear(SREG, SREG_I) && bit_is_set(*_ucsrb, UDRIE))
         // Interrupts are globally disabled, but the DR empty
         // interrupt should be enabled, so poll the DR empty flag to
         // prevent deadlock
         if (bit_is_set(*_ucsra, UDRE))
-            _tx_udr_empty_irq();
+#endif
+            _tx_reg_empty_irq();
       // If interrupts are enabled, the buffer will be emptied in an interrupt driven way
     }
     // buffer is empty now
@@ -206,8 +221,12 @@
         // register empty flag ourselves. If it is set, pretend an
         // interrupt has happened and call the handler to free up
         // space for us.
+#ifdef LINSIR
+        if (bit_is_set(LINSIR, LTXOK))
+#else
         if(bit_is_set(*_ucsra, UDRE))
-          _tx_udr_empty_irq();
+#endif
+          _tx_reg_empty_irq();
       }
     }
 

--- a/avr/cores/tiny/HardwareSerial.h
+++ b/avr/cores/tiny/HardwareSerial.h
@@ -56,8 +56,9 @@
     #define RXEN  RXEN0
     #define TXEN  TXEN0
     #define RXCIE RXCIE0
-    #define UDRIE  UDRIE0
+    #define UDRIE UDRIE0
     #define U2X   U2X0
+    #define UDRE  UDRE0
   #endif
   #if defined (UBRR0H)
     const uint8_t _rxen   = (1 << RXEN);
@@ -146,6 +147,9 @@
       virtual size_t write(uint8_t);
       using Print::write; // pull in write(str) and write(buf, size) from Print
       operator bool();
+
+      // Interrupt handler - Not intended to be called externally
+      void _tx_udr_empty_irq(void);
   };
 
   #endif

--- a/avr/cores/tiny/HardwareSerial.h
+++ b/avr/cores/tiny/HardwareSerial.h
@@ -79,42 +79,29 @@
    * I couldn't justify not explicitly optimizing the % SERIAL_BUFFER_SIZE to a & (SERIAL_BUFFER_SIZE -1))
    */
 
-
-
-  struct ring_buffer;
-
-  struct ring_buffer
-    {
-      unsigned char buffer[SERIAL_BUFFER_SIZE];
-      byte head;
-      byte tail;
-    };
-  inline void store_char(unsigned char c, ring_buffer *buffer) {
-    byte i = (buffer->head + 1) % SERIAL_BUFFER_SIZE;
-
-    // if we should be storing the received character into the location
-    // just before the tail (meaning that the head would advance to the
-    // current location of the tail), we're about to overflow the buffer
-    // and so we don't write the character or advance the head.
-    if (i != buffer->tail) {
-      buffer->buffer[buffer->head] = c;
-      buffer->head = i;
-    }
-  }
   class HardwareSerial : public Stream
   {
     private:
-      volatile ring_buffer *_rx_buffer;
-      volatile ring_buffer *_tx_buffer;
       volatile uint8_t *_ubrrh;
       volatile uint8_t *_ubrrl;
       volatile uint8_t *_ucsra;
       volatile uint8_t *_ucsrb;
       volatile uint8_t *_udr;
+
+      volatile byte _rx_buffer_head;
+      volatile byte _rx_buffer_tail;
+      volatile byte _tx_buffer_head;
+      volatile byte _tx_buffer_tail;
+
+      // Don't put any members after these buffers, since only the first
+      // 32 bytes of this struct can be accessed quickly using the ldd
+      // instruction.
+      unsigned char _rx_buffer[SERIAL_BUFFER_SIZE];
+      unsigned char _tx_buffer[SERIAL_BUFFER_SIZE];
+    
     public:
-      HardwareSerial(ring_buffer *rx_buffer, ring_buffer *tx_buffer
+      HardwareSerial(
       #if ( defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H))
-        ,
         volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
         volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
         volatile uint8_t *udr);
@@ -148,8 +135,9 @@
       using Print::write; // pull in write(str) and write(buf, size) from Print
       operator bool();
 
-      // Interrupt handler - Not intended to be called externally
+      // called insíde interrupt handlers - not intended to be called externally
       void _tx_udr_empty_irq(void);
+      void _store_rx_char(unsigned char c);
   };
 
   #endif

--- a/avr/cores/tiny/HardwareSerial.h
+++ b/avr/cores/tiny/HardwareSerial.h
@@ -136,7 +136,7 @@
       operator bool();
 
       // called insíde interrupt handlers - not intended to be called externally
-      void _tx_udr_empty_irq(void);
+      void _tx_reg_empty_irq(void);
       void _store_rx_char(unsigned char c);
   };
 

--- a/avr/cores/tiny/Serial0.cpp
+++ b/avr/cores/tiny/Serial0.cpp
@@ -10,15 +10,7 @@
     ring_buffer tx_buffer  =  { { 0 }, 0, 0 };
     #if defined(USART0_UDRE_vect)
       ISR(USART0_UDRE_vect) {
-        if (tx_buffer.head == tx_buffer.tail) {
-          // Buffer empty, so disable interrupts]
-            UCSR0B &= ~(1 << UDRIE);
-        } else {
-          // There is more data in the output buffer. Send the next byte
-          unsigned char c = tx_buffer.buffer[tx_buffer.tail];
-          tx_buffer.tail = (tx_buffer.tail + 1) % SERIAL_BUFFER_SIZE;
-          UDR0 = c;
-        }
+         Serial._tx_udr_empty_irq();
       }
     #endif
   #endif

--- a/avr/cores/tiny/Serial0.cpp
+++ b/avr/cores/tiny/Serial0.cpp
@@ -6,8 +6,6 @@
     #if !defined(USART0_UDRE_vect) && !defined(LIN_TC_vect)
       #error "Don't know what the Data Register Empty vector is called for the first UART"
     #endif
-    ring_buffer rx_buffer  =  { { 0 }, 0, 0 };
-    ring_buffer tx_buffer  =  { { 0 }, 0, 0 };
     #if defined(USART0_UDRE_vect)
       ISR(USART0_UDRE_vect) {
          Serial._tx_udr_empty_irq();
@@ -17,14 +15,14 @@
   #if defined(USART0_RX_vect)
     ISR(USART0_RX_vect) {
       unsigned char c  =  UDR0;
-      store_char(c, &rx_buffer);
+      Serial._store_rx_char(c);
     }
   #elif defined(LIN_TC_vect)
     // this is for attinyX7
     ISR(LIN_TC_vect) {
       if(LINSIR & _BV(LRXOK)) {
           unsigned char c  =  LINDAT;
-          store_char(c, &rx_buffer);
+          Serial._store_rx_char(c);
       }
       if(LINSIR & _BV(LTXOK)) {
         //PINA |= _BV(PINA5); //debug
@@ -41,8 +39,8 @@
     }
   #endif
   #if defined(UBRR0H)
-    HardwareSerial Serial(&rx_buffer, &tx_buffer, &UBRR0H, &UBRR0L, &UCSR0A, &UCSR0B, &UDR0);
+    HardwareSerial Serial(&UBRR0H, &UBRR0L, &UCSR0A, &UCSR0B, &UDR0);
   #elif defined(LINBRRH)
-    HardwareSerial Serial(&rx_buffer, &tx_buffer);
+    HardwareSerial Serial;
   #endif
 #endif

--- a/avr/cores/tiny/Serial0.cpp
+++ b/avr/cores/tiny/Serial0.cpp
@@ -8,7 +8,7 @@
     #endif
     #if defined(USART0_UDRE_vect)
       ISR(USART0_UDRE_vect) {
-         Serial._tx_udr_empty_irq();
+         Serial._tx_reg_empty_irq();
       }
     #endif
   #endif
@@ -26,15 +26,7 @@
       }
       if(LINSIR & _BV(LTXOK)) {
         //PINA |= _BV(PINA5); //debug
-        if (tx_buffer.head == tx_buffer.tail) {
-        // Buffer empty, so disable the Transmit Performed Interrupt
-          LINENIR &= ~(1 << LENTXOK); //unset LENTXOK
-        } else {
-          // There is more data in the output buffer. Send the next byte
-          unsigned char c = tx_buffer.buffer[tx_buffer.tail];
-          tx_buffer.tail = (tx_buffer.tail + 1) % SERIAL_BUFFER_SIZE;
-          LINDAT = c;
-        }
+        Serial._tx_reg_empty_irq();
       }
     }
   #endif

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -2,21 +2,19 @@
 #if (!DISABLE_UART1 && !DISABLE_UART)
   #include "HardwareSerial.h"
   #if defined(UBRR1H)
-    ring_buffer rx_buffer1  =  { { 0 }, 0, 0 };
-    ring_buffer tx_buffer1  =  { { 0 }, 0, 0 };
-    HardwareSerial Serial1(&rx_buffer1, &tx_buffer1, &UBRR1H, &UBRR1L, &UCSR1A, &UCSR1B, &UDR1);
+    HardwareSerial Serial1(&UBRR1H, &UBRR1L, &UCSR1A, &UCSR1B, &UDR1);
   #endif
   #if defined(USART1_RX_vect)
     ISR(USART1_RX_vect)
     {
       unsigned char c = UDR1;
-      store_char(c, &rx_buffer1);
+      Serial._store_rx_char(c);
     }
   #elif defined(USART1_RXC_vect)
     ISR(USART1_RXC_vect )
     {
       unsigned char c = UDR1;
-      store_char(c, &rx_buffer1);
+      Serial._store_rx_char(c);
     }
   #else
     //no UART1

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -24,17 +24,7 @@
   #ifdef USART1_UDRE_vect
     ISR(USART1_UDRE_vect)
     {
-      if (tx_buffer1.head == tx_buffer1.tail) {
-      // Buffer empty, so disable interrupts
-        UCSR1B &= ~(1 << UDRIE1);
-      }
-      else {
-        // There is more data in the output buffer. Send the next byte
-        unsigned char c = tx_buffer1.buffer[tx_buffer1.tail];
-        tx_buffer1.tail = (tx_buffer1.tail + 1) % SERIAL_BUFFER_SIZE;
-
-        UDR1 = c;
-      }
+      Serial._tx_udr_empty_irq();
     }
   #endif
 #endif

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -8,13 +8,13 @@
     ISR(USART1_RX_vect)
     {
       unsigned char c = UDR1;
-      Serial._store_rx_char(c);
+      Serial1._store_rx_char(c);
     }
   #elif defined(USART1_RXC_vect)
     ISR(USART1_RXC_vect )
     {
       unsigned char c = UDR1;
-      Serial._store_rx_char(c);
+      Serial1._store_rx_char(c);
     }
   #else
     //no UART1
@@ -22,7 +22,7 @@
   #ifdef USART1_UDRE_vect
     ISR(USART1_UDRE_vect)
     {
-      Serial._tx_reg_empty_irq();
+      Serial1._tx_reg_empty_irq();
     }
   #endif
 #endif

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -22,7 +22,7 @@
   #ifdef USART1_UDRE_vect
     ISR(USART1_UDRE_vect)
     {
-      Serial._tx_udr_empty_irq();
+      Serial._tx_reg_empty_irq();
     }
   #endif
 #endif


### PR DESCRIPTION
After (re-)introducing checks for I-bit=0 and coping with serial writes in this case, the code grew by 160 bytes ... but it works now to print strings even when interrupts are off.

After removing the level of indirection to access the ring buffers that had been introduced, perhaps to speed up the interrupts (?), things are a bit better. Now it is only 70 bytes more than before.