### PR TITLE
No TX ring buffer & TX only compile option

### DIFF
--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -57,6 +57,7 @@
 
 // Interrupt handler helpers //////////////////////////////////////////////////////////////
 
+#ifdef TXBUFFER
   void HardwareSerial::_tx_reg_empty_irq(void)
   {
     if (_tx_buffer_head == _tx_buffer_tail) {
@@ -77,6 +78,7 @@
 #endif
     }
   }
+#endif
 
   void HardwareSerial::_store_rx_char(unsigned char c) {
     byte i = (_rx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
@@ -189,28 +191,37 @@
   }
 
   void HardwareSerial::flush() {
-#ifdef LINENIR
+  #ifdef TXBUFFER
+    #ifdef LINENIR
     while (_tx_buffer_head != _tx_buffer_tail || (bit_is_set(LINENIR, LENTXOK))) {
       if (bit_is_clear(SREG, SREG_I) && bit_is_set(LINENIR, LENTXOK))
         // Interrupts are globally disabled, but the DR empty
         // interrupt should be enabled, so poll the DR empty flag to
         // prevent deadlock
         if (bit_is_set(LINSIR, LTXOK))
-#else
+    #else
     while (_tx_buffer_head != _tx_buffer_tail || (bit_is_set(*_ucsrb, UDRIE))) {
       if (bit_is_clear(SREG, SREG_I) && bit_is_set(*_ucsrb, UDRIE))
         // Interrupts are globally disabled, but the DR empty
         // interrupt should be enabled, so poll the DR empty flag to
         // prevent deadlock
         if (bit_is_set(*_ucsra, UDRE))
-#endif
+    #endif
             _tx_reg_empty_irq();
       // If interrupts are enabled, the buffer will be emptied in an interrupt driven way
     }
+  #else // without ring buffer
+    #ifdef LINSIR
+    while (bit_is_set(LINSIR, LTXOK));
+    #else
+    while (bit_is_set(*_ucsra, UDRE));
+    #endif
+  #endif
     // buffer is empty now
   }
 
   size_t HardwareSerial::write(uint8_t c) {
+  #ifdef TXBUFFER
     byte i = (_tx_buffer_head + 1)  & (SERIAL_BUFFER_SIZE - 1);
 
     // If the output buffer is full, there's nothing for it other than to
@@ -221,11 +232,11 @@
         // register empty flag ourselves. If it is set, pretend an
         // interrupt has happened and call the handler to free up
         // space for us.
-#ifdef LINSIR
+    #ifdef LINSIR
         if (bit_is_set(LINSIR, LTXOK))
-#else
+    #else
         if(bit_is_set(*_ucsra, UDRE))
-#endif
+    #endif
           _tx_reg_empty_irq();
       }
     }
@@ -245,8 +256,19 @@
         LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
       }
     #endif
-
-
+  #else // without ring buffer
+    #ifdef LINSIR
+      if (bit_is_clear(LINENIR, LENTXOK)) // nothing written yet
+         LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
+      else
+        while (bit_is_clear(LINSIR, LTXOK)); // wait for output register to empty
+    LINDAT = c;
+    #else
+    while (bit_is_clear(*_ucsra, UDRE));
+    *_udr = c;
+    #endif
+  #endif
+    
     return 1;
   }
 

--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -232,11 +232,11 @@
         // register empty flag ourselves. If it is set, pretend an
         // interrupt has happened and call the handler to free up
         // space for us.
-    #ifdef LINSIR
+   #ifdef LINSIR
         if (bit_is_set(LINSIR, LTXOK))
-    #else
+   #else
         if(bit_is_set(*_ucsra, UDRE))
-    #endif
+   #endif
           _tx_reg_empty_irq();
       }
     }
@@ -244,29 +244,29 @@
     _tx_buffer[_tx_buffer_head] = c;
     _tx_buffer_head = i;
 
-    #if (defined(UBRR0H) || defined(UBRR1H) )
-      *_ucsrb |= _udrie;
-    #else
-      if(!(LINENIR & _BV(LENTXOK))){
-        // The buffer was previously empty, so load the first byte, then enable 
-        // the TX Complete interrupt
-        unsigned char c = _tx_buffer[_tx_buffer_tail];
-        _tx_buffer_tail = (_tx_buffer_tail + 1) & (SERIAL_BUFFER_SIZE - 1);
-        LINDAT = c;
-        LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
-      }
-    #endif
+   #if (defined(UBRR0H) || defined(UBRR1H) )
+    *_ucsrb |= _udrie;
+   #else
+    if(!(LINENIR & _BV(LENTXOK))){
+      // The buffer was previously empty, so load the first byte, then enable 
+      // the TX Complete interrupt
+      unsigned char c = _tx_buffer[_tx_buffer_tail];
+      _tx_buffer_tail = (_tx_buffer_tail + 1) & (SERIAL_BUFFER_SIZE - 1);
+      LINDAT = c;
+      LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
+    }
+   #endif
   #else // without ring buffer
-    #ifdef LINSIR
-      if (bit_is_clear(LINENIR, LENTXOK)) // nothing written yet
-         LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
-      else
-        while (bit_is_clear(LINSIR, LTXOK)); // wait for output register to empty
+   #ifdef LINSIR
+    if (bit_is_clear(LINENIR, LENTXOK)) // nothing written yet
+      LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
+    else
+      while (bit_is_clear(LINSIR, LTXOK)); // wait for output register to empty
     LINDAT = c;
-    #else
+   #else
     while (bit_is_clear(*_ucsra, UDRE));
     *_udr = c;
-    #endif
+   #endif
   #endif
     
     return 1;

--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -80,6 +80,7 @@
   }
 #endif
 
+#ifndef TX_ONLY
   void HardwareSerial::_store_rx_char(unsigned char c) {
     byte i = (_rx_buffer_head + 1) % SERIAL_BUFFER_SIZE;
 
@@ -92,6 +93,7 @@
       _rx_buffer_head = i;
     }
   }
+#endif
 
 // Public Methods //////////////////////////////////////////////////////////////
 
@@ -133,7 +135,9 @@
     LINBRR = (((F_CPU * 10L / 16L / baud) + 5L) / 10L) - 1;
     LINBTR = (1 << LDISR) | (16 << LBT0);
     LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0);
+    #ifndef TX_ONLY
     LINENIR =_BV(LENRXOK);
+    #endif
   #endif
     // LINENIR only ever set to 0, 1, 2, or 3. Can we use our knowledge of the state if should be in to out advantage?
 
@@ -168,18 +172,27 @@
   }
 
   int HardwareSerial::available(void) {
+    #ifndef TX_ONLY
     return (unsigned int)(SERIAL_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail) & (SERIAL_BUFFER_SIZE - 1);
+    #else
+    return 0;
+    #endif
   }
 
   int HardwareSerial::peek(void) {
+    #ifndef TX_ONLY
     if (_rx_buffer_head == _rx_buffer_tail) {
       return -1;
     } else {
       return _rx_buffer[_rx_buffer_tail];
     }
+    #else
+    return -1;
+    #endif
   }
 
   int HardwareSerial::read(void) {
+    #ifndef TX_ONLY
     // if the head isn't ahead of the tail, we don't have any characters
     if (_rx_buffer_head == _rx_buffer_tail) {
       return -1;
@@ -188,6 +201,9 @@
       _rx_buffer_tail = (_rx_buffer_tail + 1)  & (SERIAL_BUFFER_SIZE - 1);
       return c;
     }
+    #else
+    return -1;
+    #endif
   }
 
   void HardwareSerial::flush() {
@@ -212,7 +228,8 @@
     }
   #else // without ring buffer
     #ifdef LINSIR
-    while (bit_is_set(LINSIR, LTXOK));
+    if (bit_is_set(LINENIR, LENTXOK))
+      while (bit_is_set(LINSIR, LTXOK));
     #else
     while (bit_is_set(*_ucsra, UDRE));
     #endif
@@ -259,7 +276,11 @@
   #else // without ring buffer
    #ifdef LINSIR
     if (bit_is_clear(LINENIR, LENTXOK)) // nothing written yet
+      #ifndef TX_ONLY
       LINENIR = _BV(LENTXOK) | _BV(LENRXOK);
+      #else
+      LINENIR = _BV(LENTXOK);
+      #endif
     else
       while (bit_is_clear(LINSIR, LTXOK)); // wait for output register to empty
     LINDAT = c;

--- a/avr/cores/tiny/HardwareSerial.cpp
+++ b/avr/cores/tiny/HardwareSerial.cpp
@@ -128,15 +128,20 @@
     // assign the baud_setting, a.k.a. ubbr (USART Baud Rate Register)
     *_ubrrh = baud_setting >> 8;
     *_ubrrl = baud_setting;
+   #ifndef TX_ONLY
     *_ucsrb = (_rxen | _txen | _rxcie);
-
+   #else
+    *_ucsrb = (_txen); // do not enable RX pin and interrupt of TX only
+   #endif
   #else
     LINCR = (1 << LSWRES);
     LINBRR = (((F_CPU * 10L / 16L / baud) + 5L) / 10L) - 1;
     LINBTR = (1 << LDISR) | (16 << LBT0);
-    LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0);
     #ifndef TX_ONLY
+    LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0);
     LINENIR =_BV(LENRXOK);
+    #else
+    LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD0); // Do not enable receive byte in TX-only mode
     #endif
   #endif
     // LINENIR only ever set to 0, 1, 2, or 3. Can we use our knowledge of the state if should be in to out advantage?

--- a/avr/cores/tiny/HardwareSerial.h
+++ b/avr/cores/tiny/HardwareSerial.h
@@ -17,9 +17,9 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
-
 #ifndef HardwareSerial_h
 #define HardwareSerial_h
+
 
 #if ( defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(LINBRRH)) && !USE_SOFTWARE_SERIAL
 
@@ -90,15 +90,19 @@
 
       volatile byte _rx_buffer_head;
       volatile byte _rx_buffer_tail;
+#ifdef TXBUFFER
       volatile byte _tx_buffer_head;
       volatile byte _tx_buffer_tail;
-
+#endif
+      
       // Don't put any members after these buffers, since only the first
       // 32 bytes of this struct can be accessed quickly using the ldd
       // instruction.
       unsigned char _rx_buffer[SERIAL_BUFFER_SIZE];
+#ifdef TXBUFFER
       unsigned char _tx_buffer[SERIAL_BUFFER_SIZE];
-    
+#endif
+      
     public:
       HardwareSerial(
       #if ( defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H))
@@ -136,7 +140,9 @@
       operator bool();
 
       // called insíde interrupt handlers - not intended to be called externally
+#ifdef TXBUFFER
       void _tx_reg_empty_irq(void);
+#endif
       void _store_rx_char(unsigned char c);
   };
 

--- a/avr/cores/tiny/HardwareSerial.h
+++ b/avr/cores/tiny/HardwareSerial.h
@@ -88,8 +88,10 @@
       volatile uint8_t *_ucsrb;
       volatile uint8_t *_udr;
 
+#ifndef TX_ONLY
       volatile byte _rx_buffer_head;
       volatile byte _rx_buffer_tail;
+#endif
 #ifdef TXBUFFER
       volatile byte _tx_buffer_head;
       volatile byte _tx_buffer_tail;
@@ -98,7 +100,9 @@
       // Don't put any members after these buffers, since only the first
       // 32 bytes of this struct can be accessed quickly using the ldd
       // instruction.
+#ifndef TX_ONLY
       unsigned char _rx_buffer[SERIAL_BUFFER_SIZE];
+#endif
 #ifdef TXBUFFER
       unsigned char _tx_buffer[SERIAL_BUFFER_SIZE];
 #endif
@@ -143,7 +147,9 @@
 #ifdef TXBUFFER
       void _tx_reg_empty_irq(void);
 #endif
+#ifndef TX_ONLY
       void _store_rx_char(unsigned char c);
+#endif
   };
 
   #endif

--- a/avr/cores/tiny/Serial0.cpp
+++ b/avr/cores/tiny/Serial0.cpp
@@ -6,7 +6,7 @@
     #if !defined(USART0_UDRE_vect) && !defined(LIN_TC_vect)
       #error "Don't know what the Data Register Empty vector is called for the first UART"
     #endif
-    #if defined(USART0_UDRE_vect)
+    #if defined(USART0_UDRE_vect) && defined(TXBUFFER)
       ISR(USART0_UDRE_vect) {
          Serial._tx_reg_empty_irq();
       }
@@ -25,8 +25,12 @@
           Serial._store_rx_char(c);
       }
       if(LINSIR & _BV(LTXOK)) {
+      #ifdef TXBUFFER
         //PINA |= _BV(PINA5); //debug
         Serial._tx_reg_empty_irq();
+      #else
+        // nothing to do because we check in the write routine for empty output buffer
+      #endif
       }
     }
   #endif

--- a/avr/cores/tiny/Serial0.cpp
+++ b/avr/cores/tiny/Serial0.cpp
@@ -24,14 +24,12 @@
           unsigned char c  =  LINDAT;
           Serial._store_rx_char(c);
       }
-      if(LINSIR & _BV(LTXOK)) {
       #ifdef TXBUFFER
+      if(LINSIR & _BV(LTXOK)) {
         //PINA |= _BV(PINA5); //debug
         Serial._tx_reg_empty_irq();
-      #else
-        // nothing to do because we check in the write routine for empty output buffer
-      #endif
       }
+      #endif
     }
   #endif
   #if defined(UBRR0H)

--- a/avr/cores/tiny/Serial0.cpp
+++ b/avr/cores/tiny/Serial0.cpp
@@ -12,7 +12,7 @@
       }
     #endif
   #endif
-  #if defined(USART0_RX_vect)
+  #if defined(USART0_RX_vect) && !defined(TX_ONLY)
     ISR(USART0_RX_vect) {
       unsigned char c  =  UDR0;
       Serial._store_rx_char(c);
@@ -20,10 +20,12 @@
   #elif defined(LIN_TC_vect)
     // this is for attinyX7
     ISR(LIN_TC_vect) {
+      #ifndef TX_ONLY
       if(LINSIR & _BV(LRXOK)) {
           unsigned char c  =  LINDAT;
           Serial._store_rx_char(c);
       }
+      #endif
       #ifdef TXBUFFER
       if(LINSIR & _BV(LTXOK)) {
         //PINA |= _BV(PINA5); //debug

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -19,7 +19,7 @@
   #else
     //no UART1
   #endif
-  #ifdef USART1_UDRE_vect
+  #if defined(USART1_UDRE_vect) && defined(TXBUFFER)
     ISR(USART1_UDRE_vect)
     {
       Serial1._tx_reg_empty_irq();

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -4,13 +4,13 @@
   #if defined(UBRR1H)
     HardwareSerial Serial1(&UBRR1H, &UBRR1L, &UCSR1A, &UCSR1B, &UDR1);
   #endif
-  #if defined(USART1_RX_vect)
+#if defined(USART1_RX_vect) && !defined(TX_ONLY)
     ISR(USART1_RX_vect)
     {
       unsigned char c = UDR1;
       Serial1._store_rx_char(c);
     }
-  #elif defined(USART1_RXC_vect)
+  #elif defined(USART1_RXC_vect) && defined(TX_ONLY)
     ISR(USART1_RXC_vect )
     {
       unsigned char c = UDR1;

--- a/avr/cores/tiny/Serial1.cpp
+++ b/avr/cores/tiny/Serial1.cpp
@@ -10,7 +10,7 @@
       unsigned char c = UDR1;
       Serial1._store_rx_char(c);
     }
-  #elif defined(USART1_RXC_vect) && defined(TX_ONLY)
+  #elif defined(USART1_RXC_vect) && !defined(TX_ONLY)
     ISR(USART1_RXC_vect )
     {
       unsigned char c = UDR1;

--- a/avr/extras/tests/serial/ser/ser.ino
+++ b/avr/extras/tests/serial/ser/ser.ino
@@ -2,6 +2,7 @@
 #define BPS 9600
 //#define CORR_OSCCAL 0x68 // for 43U
 
+
 void setup() {
 #ifdef CORR_OSCCAL  
   OSCCAL = CORR_OSCCAL;


### PR DESCRIPTION
This PR disables the TX ring buffer for hardware serial conditionally (if TXBUFFER is undefined). It means that we only have a 1-byte output buffer instead of a 16-byte buffer. This is still better than in the case of software serial, where we have a 0-byte output buffer. And it should not affect serial performance dramatically (only if we have a streaming output with short but varying output intervals).

Savings for USART based code:  226 byte flash, 18 byte RAM
Savings for LIN based code (87/167): 214 byte flash, 18  byte RAM