### PR TITLE
fixing pragma problems

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -127,10 +127,10 @@ preproc.macros.flags=-w -x c++ -E -CC
 recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DCLOCK_SOURCE={build.clocksource} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # Generating options.XXXX_flags using #pragma
-recipe.hooks.prebuild.1.pattern=/bin/bash "{runtime.platform.path}/scripts/pragma.sh" "{compiler.path}{compiler.cpp.cmd}" "{sketch_path}" "{build.path}" "{build.project_name}" debug_flags
-recipe.hooks.prebuild.2.pattern=/bin/bash "{runtime.platform.path}/scripts/pragma.sh" "{compiler.path}{compiler.cpp.cmd}" "{sketch_path}" "{build.path}" "{build.project_name}" release_flags
-recipe.hooks.prebuild.1.pattern.windows="{runtime.platform.path}\scripts\pragma.bat" "{compiler.path}{compiler.cpp.cmd}" "{sketch_path}" "{build.path}" "{build.project_name}" debug_flags
-recipe.hooks.prebuild.2.pattern.windows="{runtime.platform.path}\scripts\pragma.bat" "{compiler.path}{compiler.cpp.cmd}" "{sketch_path}" "{build.path}" "{build.project_name}" release_flags
+recipe.hooks.prebuild.1.pattern=/bin/bash "{runtime.platform.path}/scripts/pragma.sh" "{compiler.path}{compiler.cpp.cmd}" "{build.source.path}" "{build.path}" "{build.project_name}" debug_flags
+recipe.hooks.prebuild.2.pattern=/bin/bash "{runtime.platform.path}/scripts/pragma.sh" "{compiler.path}{compiler.cpp.cmd}" "{build.source.path}" "{build.path}" "{build.project_name}" release_flags
+recipe.hooks.prebuild.1.pattern.windows="{runtime.platform.path}\scripts\pragma.bat" "{compiler.path}{compiler.cpp.cmd}" "{build.source.path}" "{build.path}" "{build.project_name}" debug_flags
+recipe.hooks.prebuild.2.pattern.windows="{runtime.platform.path}\scripts\pragma.bat" "{compiler.path}{compiler.cpp.cmd}" "{build.source.path}" "{build.path}" "{build.project_name}" release_flags
 
 
 # AVR Uploader/Programmers tools

--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -11,9 +11,9 @@ version=0.6.0
 # ---------------------
 
 # Optimization flags for debugging
-compiler.optimization_flags=-Os -ggdb3 -flto -DNDEBUG @{build.path}/options.release_flags
-compiler.optimization_flags.release=-Os -ggdb3 -flto -DNDEBUG @{build.path}/options.release_flags
-compiler.optimization_flags.debug=-Og -ggdb3 -fno-lto -DDEBUG @{build.path}/options.debug_flags
+compiler.optimization_flags=-Os -ggdb3 -flto -DNDEBUG "@{build.path}/options.release_flags"
+compiler.optimization_flags.release=-Os -ggdb3 -flto -DNDEBUG "@{build.path}/options.release_flags"
+compiler.optimization_flags.debug=-Og -ggdb3 -fno-lto -DDEBUG "@{build.path}/options.debug_flags"
 
 build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_AVR -DTINYCORE="{version}"
 build.optiondefines=-DF_CPU={build.f_cpu} -DCLOCK_SOURCE={build.clocksource}

--- a/avr/scripts/pragma.bat
+++ b/avr/scripts/pragma.bat
@@ -89,7 +89,7 @@ for /f "usebackq delims=" %%L in ("%TMP_OUT%") do (
 
   REM Now we can match deterministically
   REM Accept both "pragma arduino debug_flags" and "pragma arduino release_flags"
-  echo(!LINE! | findstr /I /C:"pragma arduino %FLAG_NAME% " >nul
+  echo "!LINE!" | findstr /I /C:"pragma arduino %FLAG_NAME% " >nul
   if not errorlevel 1 (
     if !HASH! EQU 1 (
       REM Strip prefix
@@ -112,7 +112,7 @@ for /f "usebackq delims=" %%L in ("%TMP_OUT%") do (
 
 > "%OUT_FILE%" (<nul set /p ="%OPTIONS% ")
 
-FC %OUT_FILE% %BAK_FILE% > NUL
+FC "%OUT_FILE%" "%BAK_FILE%" > NUL
 if errorlevel 1 (
    echo "Options changed: Deleting cached object files"
    del "%OSKETCH%" 2>NUL

--- a/avr/scripts/pragma.sh
+++ b/avr/scripts/pragma.sh
@@ -7,13 +7,13 @@
 # $5 = flag name ('build_flags, 'release_flags', or 'debug_flags')
 
 # create previous option file if not already there
-touch $3/options.$5
+touch "$3/options.$5"
 
 # make a backup copy 
-cp $3/options.$5 $3/options.$5.bak
+cp "$3/options.$5" "$3/options.$5.bak"
 
 # create new option file
-$1 -fpreprocessed -dD -E -x c++ $2/$4 | grep -E "^\s*#\s*pragma\s+arduino\s+$5" | sed -E 's/# *pragma +arduino +(debug|release|build)_flags//'g | tr '\n' ' ' >$3/options.$5
+$1 -fpreprocessed -dD -E -x c++ "$2/$4" | grep -E "^\s*#\s*pragma\s+arduino\s+$5" | sed -E 's/# *pragma +arduino +(debug|release|build)_flags//g' | tr '\n' ' ' >"$3/options.$5"
 
 # compare old and new options
 # if different, then delete all cached *.o and *.a files
@@ -21,26 +21,26 @@ $1 -fpreprocessed -dD -E -x c++ $2/$4 | grep -E "^\s*#\s*pragma\s+arduino\s+$5" 
 # there are only two directories called 'sketches' and 'cores',
 # and 'cores' contains only directories with just one file
 # 'core.a', then delete the 'cores' folder.
-if  [[ `diff -q $3/options.$5 $3/options.$5.bak` ]]; then
+if  [[ $(diff -q "$3/options.$5" "$3/options.$5.bak") ]]; then
     echo "Options changed: Delete cached object files"
-    rm -rf $3/core/*.a
-    rm -rf $3/core/*.o
-    rm -rf $3/sketch/*.a
+    rm -rf "$3/core/*.a"
+    rm -rf "$3/core/*.o"
+    rm -rf "$3/sketch/*.a"
     
     if [[ -d $3/../../cores ]] &&  [[ -d $3/../../sketches ]]; then
-        filenums=`find $3/../../ -maxdepth 1 -print | wc -l`
+        filenums=$(find "$3"/../../ -maxdepth 1 -print | wc -l)
         if [[ $filenums -eq 3 ]]; then
-            corefolders=`find $3/../../cores -type d -print | wc -l`
-            immediate=`find $3/../../cores -maxdepth 1 -print | wc -l`
-            corefiles=`find $3/../../cores -type f -name "core.a" -print -or -name ".last-used" -print | wc -l`
-            if [[ $(($corefiles/2)) -eq $(($corefolders-1)) ]] && [[ $corefolders -eq $immediate ]]; then
+            corefolders=$(find "$3"/../../cores -type d -print | wc -l)
+            immediate=$(find "$3"/../../cores -maxdepth 1 -print | wc -l)
+            corefiles=$(find "$3"/../../cores -type f -name "core.a" -print -or -name ".last-used" -print | wc -l)
+            if [[ $((corefiles/2)) -eq $((corefolders-1)) ]] && [[ $corefolders -eq $immediate ]]; then
                 echo "Delete cached cores"
-                rm -rf $3/../../cores
+                rm -rf "$3"/../../cores
             fi
         fi
      fi
 fi
 
 #remove backup options
-rm $3/options.$5.bak
+rm "$3/options.$5.bak"
 

--- a/avr/scripts/size.bat
+++ b/avr/scripts/size.bat
@@ -28,7 +28,7 @@ set /a maxflash=%maxflash% - %boot%
 REM Calculate flash and RAM from avr-size output
 set flash=0
 set ram=0
-for /f "tokens=1,2" %%a in ('%sizeprog% -A %sketch%') do (
+for /f "tokens=1,2" %%a in ('%sizeprog% -A "%sketch%"') do (
     if "%%a"==".text"   set /a flash+=%%b
     if "%%a"==".data"   set /a flash+=%%b
     if "%%a"==".data"   set /a ram+=%%b
@@ -51,4 +51,4 @@ if %flash% GTR %maxflash% (
    )
 
 REM Output JSON
-echo {"output": "Flash memory used: %flash% bytes out of %maxflash% (%flashpercent%%%). RAM used for global variables: %ram% bytes out of %maxram%.","severity": "%severity%",%errstr%"sections": [{"name": "text","size": %flash%,"max_size": %maxflash%},{"name": "data","size": %ram%,"max_size": %maxram%}]}
+echo {"output": "Flash memory used: %flash% bytes out of %maxflash% (%flashpercent%%%).\nRAM used for global variables: %ram% bytes out of %maxram%.","severity": "%severity%",%errstr%"sections": [{"name": "text","size": %flash%,"max_size": %maxflash%},{"name": "data","size": %ram%,"max_size": %maxram%}]}

--- a/avr/scripts/size.sh
+++ b/avr/scripts/size.sh
@@ -10,19 +10,19 @@
 if [[ -z "$8" ]]; then
     boot=0
 else
-    if [[ `$5 -c dryrun -p $7 -C $6 $8 -qq 2>/dev/null` ]]; then
-        boot=`$5 -c dryrun -p $7 -C $6 $8 -qq | awk '{print $2}'`
+    if [[ $("$5" -c dryrun -p "$7" -C "$6" "$8" -qq 2>/dev/null) ]]; then
+        boot=$("$5" -c dryrun -p "$7" -C "$6" "$8" -qq | awk '{print $2}')
     else
         boot=256
     fi
 fi
-maxflash=$(($3-$boot))
+maxflash=$(($3-boot))
 maxram=$4
-flash=`$1 -A $2 | egrep  '^(.text|.data)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
-ram=`$1 -A $2 | egrep  '^(.data|.bss|.noinit)\s+([0-9]+).*' | awk '{s+=$2}END{print s}'`
+flash=$($1 -A "$2" | grep -E '^(.text|.data)\s+([0-9]+).*' | awk '{s+=$2}END{print s}')
+ram=$($1 -A "$2" | grep -E '^(.data|.bss|.noinit)\s+([0-9]+).*' | awk '{s+=$2}END{print s}')
 flashpercent=$((flash*100/maxflash))
-printf  '{  "output": "Flash memory used: %d bytes out of %d (%d%%). ' $flash $maxflash $flashpercent
-printf  'RAM used for global variables: %d bytes out of %d.",' $ram $maxram 
+printf  '{  "output": "Flash memory used: %d bytes out of %d (%d%%).\\n' "$flash" $maxflash $flashpercent
+printf  'RAM used for global variables: %d bytes out of %d.",' "$ram" "$maxram" 
 if [[ $ram -gt $maxram ]]; then
     printf '"severity": "error", "error": "Not enough RAM", '
 elif [[ $flash -gt $maxflash ]]; then
@@ -30,5 +30,5 @@ elif [[ $flash -gt $maxflash ]]; then
 else
     printf '"severity": "info", '
 fi
-printf '"sections": [    { "name": "text", "size": %d, "max_size": %d },' $flash $maxflash 
-printf '{ "name": "data", "size": %d, "max_size": %d }  ]}' $ram $maxram
+printf '"sections": [    { "name": "text", "size": %d, "max_size": %d },' "$flash" $maxflash 
+printf '{ "name": "data", "size": %d, "max_size": %d }  ]}' "$ram" "$maxram"


### PR DESCRIPTION
This PR fixes four bugs in connection with pragma processing:
1. Blanks in the sketch path would lead to error messages during pragma preprocessing (#38)
2. Blanks in the build path are also a problem, although they probably do not happen that often
3. The pragma.bat script contained an unquoted `echo` expression, which led to strange error messages and writing funny files into the Arduino IDE folder (#39)
4. In Arduino IDE 1.8.19, {sketch_path} is undefined when preprocessing starts, which results in a compilation error. Now, {build.source.path} is used (#37)